### PR TITLE
Fix TCPConnectionHandler thread interruptions

### DIFF
--- a/src/main/java/com/ghgande/j2mod/modbus/net/TCPConnectionHandler.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/net/TCPConnectionHandler.java
@@ -86,7 +86,7 @@ public class TCPConnectionHandler implements Runnable {
 
                 // Write the response message.
                 transport.writeMessage(response);
-            } while (!Thread.interrupted());
+            } while (!Thread.currentThread().isInterrupted());
         }
         catch (ModbusIOException ex) {
             if (!ex.isEOF()) {

--- a/src/main/java/com/ghgande/j2mod/modbus/net/TCPConnectionHandler.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/net/TCPConnectionHandler.java
@@ -64,6 +64,7 @@ public class TCPConnectionHandler implements Runnable {
         transport = connection.getModbusTransport();
     }
 
+    @Override
     public void run() {
         try {
             do {
@@ -85,7 +86,7 @@ public class TCPConnectionHandler implements Runnable {
 
                 // Write the response message.
                 transport.writeMessage(response);
-            } while (true);
+            } while (!Thread.interrupted());
         }
         catch (ModbusIOException ex) {
             if (!ex.isEOF()) {
@@ -93,12 +94,7 @@ public class TCPConnectionHandler implements Runnable {
             }
         }
         finally {
-            try {
-                connection.close();
-            }
-            catch (Exception ex) {
-                // ignore
-            }
+            connection.close();
         }
     }
 }


### PR DESCRIPTION
Fixed the `TCPConnectionHandler`'s infinite loop to be able to stop when the current thread is being interrupted. Also removed an unnecessary try/catch block because `connection.close()` already catches exceptions.