### PR TITLE
Fix for TCPConnectionHandler's infinite loop

### DIFF
--- a/src/main/java/com/ghgande/j2mod/modbus/net/TCPConnectionHandler.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/net/TCPConnectionHandler.java
@@ -85,7 +85,7 @@ public class TCPConnectionHandler implements Runnable {
 
                 // Write the response message.
                 transport.writeMessage(response);
-            } while (true);
+            } while (!Thread.currentThread().isInterrupted());
         }
         catch (ModbusIOException ex) {
             if (!ex.isEOF()) {
@@ -93,12 +93,7 @@ public class TCPConnectionHandler implements Runnable {
             }
         }
         finally {
-            try {
-                connection.close();
-            }
-            catch (Exception ex) {
-                // ignore
-            }
+        	connection.close();
         }
     }
 }


### PR DESCRIPTION
Fixed `TCPConnectionHandler`'s loop to be able to stop when the thread is interrupted.
Additionally removed an unnecesssary try/catch-block, as `connection.close()` already takes care of catching exceptions.