### PR TITLE
Facilitate the use of multiple process images in the ModbusCoupler.

### DIFF
--- a/src/main/java/com/ghgande/j2mod/modbus/ModbusCoupler.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/ModbusCoupler.java
@@ -15,11 +15,15 @@
  */
 package com.ghgande.j2mod.modbus;
 
+import java.util.HashMap;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.ghgande.j2mod.modbus.procimg.DefaultProcessImageFactory;
 import com.ghgande.j2mod.modbus.procimg.ProcessImage;
 import com.ghgande.j2mod.modbus.procimg.ProcessImageFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Class implemented following a Singleton pattern, to couple the slave side
@@ -41,8 +45,7 @@ public class ModbusCoupler {
     private static ModbusCoupler modbusCoupler; // Singleton reference
 
     // instance attributes
-    private ProcessImage processImage;
-    private int unitID = Modbus.DEFAULT_UNIT_ID;
+    private Map<Integer, ProcessImage> processImages = new HashMap<Integer, ProcessImage>();
     private boolean master = true;
     private ProcessImageFactory processImageFactory;
 
@@ -91,20 +94,21 @@ public class ModbusCoupler {
      * Returns a reference to the <tt>ProcessImage</tt> of this
      * <tt>ModbusCoupler</tt>.
      *
+     * @param unitID the unitID of the process image to fetch.
      * @return the <tt>ProcessImage</tt>.
      */
-    public synchronized ProcessImage getProcessImage() {
-        return processImage;
+    public synchronized ProcessImage getProcessImage(Integer unitID) {
+        return processImages.get(unitID);
     }
 
     /**
      * Sets the reference to the <tt>ProcessImage</tt> of this
-     * <tt>ModbusCoupler</tt>.
+     * <tt>ModbusCoupler</tt> by its <tt>unitID</tt>.
      *
      * @param procimg the <tt>ProcessImage</tt> to be set.
      */
     public synchronized void setProcessImage(ProcessImage procimg) {
-        processImage = procimg;
+        processImages.put(procimg.getUnitID(), procimg);
     }
 
     /**

--- a/src/main/java/com/ghgande/j2mod/modbus/io/ModbusASCIITransport.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/io/ModbusASCIITransport.java
@@ -109,19 +109,19 @@ public class ModbusASCIITransport extends ModbusSerialTransport {
                         continue;
                     }
                     byteInputStream.reset(inBuffer, byteInputOutputStream.size());
-                    in = byteInputStream.readUnsignedByte();
+                    int unitID = byteInputStream.readUnsignedByte();
 
                     //check message with this slave unit identifier
-                    ProcessImage spi = ModbusCoupler.getReference().getProcessImage();
+                    ProcessImage spi = ModbusCoupler.getReference().getProcessImage(unitID);
                     if (spi == null) {
                         continue;
                     }
-                    if (in != spi.getUnitID()) {
+                    if (unitID != spi.getUnitID()) {
                         continue;
                     }
-                    in = byteInputStream.readUnsignedByte();
+                    int functionCode = byteInputStream.readUnsignedByte();
                     //create request
-                    request = ModbusRequest.createModbusRequest(in);
+                    request = ModbusRequest.createModbusRequest(functionCode);
                     request.setHeadless();
                     //read message
                     byteInputStream.reset(inBuffer, byteInputOutputStream.size());

--- a/src/main/java/com/ghgande/j2mod/modbus/msg/MaskWriteRegisterRequest.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/msg/MaskWriteRegisterRequest.java
@@ -143,7 +143,7 @@ public final class MaskWriteRegisterRequest extends ModbusRequest {
         MaskWriteRegisterResponse response;
 
         // Get the process image.
-        ProcessImage procimg = ModbusCoupler.getReference().getProcessImage();
+        ProcessImage procimg = ModbusCoupler.getReference().getProcessImage(getUnitID());
         try {
             Register register = procimg.getRegister(reference);
 

--- a/src/main/java/com/ghgande/j2mod/modbus/msg/ReadCoilsRequest.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/msg/ReadCoilsRequest.java
@@ -96,7 +96,7 @@ public final class ReadCoilsRequest extends ModbusRequest {
         DigitalOut[] douts;
 
         // 1. get process image
-        ProcessImage procimg = ModbusCoupler.getReference().getProcessImage();
+        ProcessImage procimg = ModbusCoupler.getReference().getProcessImage(getUnitID());
         // 2. get input discretes range
         try {
             douts = procimg.getDigitalOutRange(getReference(), getBitCount());

--- a/src/main/java/com/ghgande/j2mod/modbus/msg/ReadFIFOQueueRequest.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/msg/ReadFIFOQueueRequest.java
@@ -96,7 +96,7 @@ public final class ReadFIFOQueueRequest extends ModbusRequest {
         InputRegister[] registers;
 
         // Get the process image.
-        ProcessImage procimg = ModbusCoupler.getReference().getProcessImage();
+        ProcessImage procimg = ModbusCoupler.getReference().getProcessImage(getUnitID());
 
         try {
             // Get the FIFO queue location and read the count of available

--- a/src/main/java/com/ghgande/j2mod/modbus/msg/ReadFileRecordRequest.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/msg/ReadFileRecordRequest.java
@@ -136,7 +136,7 @@ public final class ReadFileRecordRequest extends ModbusRequest {
         response = (ReadFileRecordResponse)getResponse();
 
         // Get the process image.
-        ProcessImage procimg = ModbusCoupler.getReference().getProcessImage();
+        ProcessImage procimg = ModbusCoupler.getReference().getProcessImage(getUnitID());
 
         // There is a list of requests to be resolved.
         try {

--- a/src/main/java/com/ghgande/j2mod/modbus/msg/ReadInputDiscretesRequest.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/msg/ReadInputDiscretesRequest.java
@@ -101,7 +101,7 @@ public final class ReadInputDiscretesRequest extends ModbusRequest {
         DigitalIn[] dins;
 
         // 1. get process image
-        ProcessImage procimg = ModbusCoupler.getReference().getProcessImage();
+        ProcessImage procimg = ModbusCoupler.getReference().getProcessImage(getUnitID());
         // 2. get input discretes range
         try {
             dins = procimg.getDigitalInRange(getReference(), getBitCount());

--- a/src/main/java/com/ghgande/j2mod/modbus/msg/ReadInputRegistersRequest.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/msg/ReadInputRegistersRequest.java
@@ -89,7 +89,7 @@ public final class ReadInputRegistersRequest extends ModbusRequest {
         InputRegister[] inpregs;
 
         // 1. get process image
-        ProcessImage procimg = ModbusCoupler.getReference().getProcessImage();
+        ProcessImage procimg = ModbusCoupler.getReference().getProcessImage(getUnitID());
         // 2. get input registers range
         try {
             inpregs = procimg.getInputRegisterRange(getReference(), getWordCount());

--- a/src/main/java/com/ghgande/j2mod/modbus/msg/ReadMultipleRegistersRequest.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/msg/ReadMultipleRegistersRequest.java
@@ -89,7 +89,7 @@ public final class ReadMultipleRegistersRequest extends ModbusRequest {
         Register[] regs;
 
         // 1. get process image
-        ProcessImage procimg = ModbusCoupler.getReference().getProcessImage();
+        ProcessImage procimg = ModbusCoupler.getReference().getProcessImage(getUnitID());
         // 2. get input registers range
         try {
             regs = procimg.getRegisterRange(getReference(), getWordCount());

--- a/src/main/java/com/ghgande/j2mod/modbus/msg/ReadWriteMultipleRequest.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/msg/ReadWriteMultipleRequest.java
@@ -115,7 +115,7 @@ public final class ReadWriteMultipleRequest extends ModbusRequest {
         Register[] writeRegs;
 
         // 1. get process image
-        ProcessImage procimg = ModbusCoupler.getReference().getProcessImage();
+        ProcessImage procimg = ModbusCoupler.getReference().getProcessImage(getUnitID());
         // 2. get input registers range
         try {
             readRegs = procimg.getRegisterRange(getReadReference(), getReadWordCount());

--- a/src/main/java/com/ghgande/j2mod/modbus/msg/WriteCoilRequest.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/msg/WriteCoilRequest.java
@@ -86,7 +86,7 @@ public final class WriteCoilRequest extends ModbusRequest {
         DigitalOut dout;
 
         // 1. get process image
-        ProcessImage procimg = ModbusCoupler.getReference().getProcessImage();
+        ProcessImage procimg = ModbusCoupler.getReference().getProcessImage(getUnitID());
         // 2. get coil
         try {
             dout = procimg.getDigitalOut(getReference());

--- a/src/main/java/com/ghgande/j2mod/modbus/msg/WriteFileRecordRequest.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/msg/WriteFileRecordRequest.java
@@ -137,7 +137,7 @@ public final class WriteFileRecordRequest extends ModbusRequest {
         response = (WriteFileRecordResponse)getResponse();
 
         // Get the process image.
-        ProcessImage procimg = ModbusCoupler.getReference().getProcessImage();
+        ProcessImage procimg = ModbusCoupler.getReference().getProcessImage(getUnitID());
 
         // There is a list of requests to be resolved.
         try {

--- a/src/main/java/com/ghgande/j2mod/modbus/msg/WriteMultipleCoilsRequest.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/msg/WriteMultipleCoilsRequest.java
@@ -115,7 +115,7 @@ public final class WriteMultipleCoilsRequest extends ModbusRequest {
         DigitalOut douts[];
 
         // 1. get process image
-        ProcessImage procimg = ModbusCoupler.getReference().getProcessImage();
+        ProcessImage procimg = ModbusCoupler.getReference().getProcessImage(getUnitID());
         // 2. get coil range
         try {
             douts = procimg.getDigitalOutRange(reference, coils.size());

--- a/src/main/java/com/ghgande/j2mod/modbus/msg/WriteMultipleRegistersRequest.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/msg/WriteMultipleRegistersRequest.java
@@ -104,7 +104,7 @@ public final class WriteMultipleRegistersRequest extends ModbusRequest {
         if (nonWordDataHandler == null) {
             Register[] regs;
             // 1. get process image
-            ProcessImage procimg = ModbusCoupler.getReference().getProcessImage();
+            ProcessImage procimg = ModbusCoupler.getReference().getProcessImage(getUnitID());
             // 2. get registers
             try {
                 regs = procimg.getRegisterRange(getReference(), getWordCount());

--- a/src/main/java/com/ghgande/j2mod/modbus/msg/WriteSingleRegisterRequest.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/msg/WriteSingleRegisterRequest.java
@@ -87,7 +87,7 @@ public final class WriteSingleRegisterRequest extends ModbusRequest {
         Register reg;
 
         // 1. get process image
-        ProcessImage procimg = ModbusCoupler.getReference().getProcessImage();
+        ProcessImage procimg = ModbusCoupler.getReference().getProcessImage(getUnitID());
         // 2. get register
         try {
             reg = procimg.getRegister(reference);

--- a/src/main/java/com/ghgande/j2mod/modbus/net/AbstractModbusListener.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/net/AbstractModbusListener.java
@@ -133,7 +133,7 @@ public abstract class AbstractModbusListener implements Runnable {
         ModbusResponse response;
 
         // Test if Process image exists and has a correct unit ID
-        ProcessImage spi = ModbusCoupler.getReference().getProcessImage();
+        ProcessImage spi = ModbusCoupler.getReference().getProcessImage(request.getUnitID());
         if (spi == null ||
             (spi.getUnitID() != 0 && request.getUnitID() != spi.getUnitID())) {
             response = request.createExceptionResponse(Modbus.ILLEGAL_ADDRESS_EXCEPTION);

--- a/src/main/java/com/ghgande/j2mod/modbus/net/TCPConnectionHandler.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/net/TCPConnectionHandler.java
@@ -72,7 +72,7 @@ public class TCPConnectionHandler implements Runnable {
                 ModbusResponse response;
 
                 // Test if Process image exists and the Unit ID is good
-                ProcessImage spi = ModbusCoupler.getReference().getProcessImage();
+                ProcessImage spi = ModbusCoupler.getReference().getProcessImage(request.getUnitID());
                 if (spi == null ||
                         (spi.getUnitID() != 0 && request.getUnitID() != spi.getUnitID())) {
                     response = request.createExceptionResponse(Modbus.ILLEGAL_ADDRESS_EXCEPTION);


### PR DESCRIPTION
This change facilitates the use of multiple process images in the ModbusCoupler. This allows for communicating concurrently with multiple devices at the same time. The process images are differentiated by their respective unitIDs.