### PR TITLE
Fix unit tests on linux

### DIFF
--- a/src/test/java/com/ghgande/j2mod/modbus/utils/AbstractTestModbusTCPSlave.java
+++ b/src/test/java/com/ghgande/j2mod/modbus/utils/AbstractTestModbusTCPSlave.java
@@ -24,8 +24,6 @@ import org.slf4j.LoggerFactory;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 
-import java.io.File;
-
 /**
  * All the slave unit tests extend this class so that the system will automatically
  * create a test slave to work with and tear it down after a run
@@ -37,13 +35,12 @@ public class AbstractTestModbusTCPSlave extends AbstractTestModbusTCPMaster {
 
     private static final Logger logger = LoggerFactory.getLogger(AbstractTestModbusTCPSlave.class);
     private static AbstractModbusListener listener = null;
-    private static File modPollTool;
 
     @BeforeClass
     public static void setUpSlave() {
         assumeTrue("This platform does not support modpoll so the result of this test will be ignored", TestUtils.platformSupportsModPoll());
         try {
-            modPollTool = TestUtils.loadModPollTool();
+            TestUtils.loadModPollTool();
             listener = createTCPSlave();
         }
         catch (Exception e) {
@@ -114,8 +111,8 @@ public class AbstractTestModbusTCPSlave extends AbstractTestModbusTCPMaster {
      */
     private static boolean execModPoll(int register, int type, Integer outValue, String expectedOutput, int numberOfRegisters) {
         try {
-            String output = TestUtils.execToString(String.format("%s -m tcp -p 1502 -a %d -r %d -t %d -c %d -1 %s %s",
-                    modPollTool.toString(), UNIT_ID, register, type, numberOfRegisters,
+            String output = TestUtils.execToString(String.format("%smodpoll -m tcp -p 1502 -a %d -r %d -t %d -c %d -1 %s %s",
+                    TestUtils.getTemporaryDirectory(), UNIT_ID, register, type, numberOfRegisters,
                     LOCALHOST, outValue == null ? "" : outValue));
             boolean returnValue = output != null && output.replaceAll("[\r]", "").contains(expectedOutput);
             if (!returnValue) {

--- a/src/test/java/com/ghgande/j2mod/modbus/utils/AbstractTestModbusTCPSlave.java
+++ b/src/test/java/com/ghgande/j2mod/modbus/utils/AbstractTestModbusTCPSlave.java
@@ -24,6 +24,8 @@ import org.slf4j.LoggerFactory;
 import static org.junit.Assert.fail;
 import static org.junit.Assume.assumeTrue;
 
+import java.io.File;
+
 /**
  * All the slave unit tests extend this class so that the system will automatically
  * create a test slave to work with and tear it down after a run
@@ -35,12 +37,13 @@ public class AbstractTestModbusTCPSlave extends AbstractTestModbusTCPMaster {
 
     private static final Logger logger = LoggerFactory.getLogger(AbstractTestModbusTCPSlave.class);
     private static AbstractModbusListener listener = null;
+    private static File modPollTool;
 
     @BeforeClass
     public static void setUpSlave() {
         assumeTrue("This platform does not support modpoll so the result of this test will be ignored", TestUtils.platformSupportsModPoll());
         try {
-            TestUtils.loadModPollTool();
+            modPollTool = TestUtils.loadModPollTool();
             listener = createTCPSlave();
         }
         catch (Exception e) {
@@ -111,8 +114,8 @@ public class AbstractTestModbusTCPSlave extends AbstractTestModbusTCPMaster {
      */
     private static boolean execModPoll(int register, int type, Integer outValue, String expectedOutput, int numberOfRegisters) {
         try {
-            String output = TestUtils.execToString(String.format("%smodpoll -m tcp -p 1502 -a %d -r %d -t %d -c %d -1 %s %s",
-                    TestUtils.getTemporaryDirectory(), UNIT_ID, register, type, numberOfRegisters,
+            String output = TestUtils.execToString(String.format("%s -m tcp -p 1502 -a %d -r %d -t %d -c %d -1 %s %s",
+                    modPollTool.toString(), UNIT_ID, register, type, numberOfRegisters,
                     LOCALHOST, outValue == null ? "" : outValue));
             boolean returnValue = output != null && output.replaceAll("[\r]", "").contains(expectedOutput);
             if (!returnValue) {

--- a/src/test/java/com/ghgande/j2mod/modbus/utils/AbstractTestModbusTCPSlave.java
+++ b/src/test/java/com/ghgande/j2mod/modbus/utils/AbstractTestModbusTCPSlave.java
@@ -16,6 +16,8 @@
 package com.ghgande.j2mod.modbus.utils;
 
 import com.ghgande.j2mod.modbus.net.AbstractModbusListener;
+
+import java.io.File;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.slf4j.Logger;
@@ -35,12 +37,13 @@ public class AbstractTestModbusTCPSlave extends AbstractTestModbusTCPMaster {
 
     private static final Logger logger = LoggerFactory.getLogger(AbstractTestModbusTCPSlave.class);
     private static AbstractModbusListener listener = null;
+    private static File modPollTool;
 
     @BeforeClass
     public static void setUpSlave() {
         assumeTrue("This platform does not support modpoll so the result of this test will be ignored", TestUtils.platformSupportsModPoll());
         try {
-            TestUtils.loadModPollTool();
+            modPollTool = TestUtils.loadModPollTool();
             listener = createTCPSlave();
         }
         catch (Exception e) {
@@ -111,8 +114,8 @@ public class AbstractTestModbusTCPSlave extends AbstractTestModbusTCPMaster {
      */
     private static boolean execModPoll(int register, int type, Integer outValue, String expectedOutput, int numberOfRegisters) {
         try {
-            String output = TestUtils.execToString(String.format("%smodpoll -m tcp -p 1502 -a %d -r %d -t %d -c %d -1 %s %s",
-                    TestUtils.getTemporaryDirectory(), UNIT_ID, register, type, numberOfRegisters,
+            String output = TestUtils.execToString(String.format("%s -m tcp -p 1502 -a %d -r %d -t %d -c %d -1 %s %s",
+                    modPollTool.toString(), UNIT_ID, register, type, numberOfRegisters,
                     LOCALHOST, outValue == null ? "" : outValue));
             boolean returnValue = output != null && output.replaceAll("[\r]", "").contains(expectedOutput);
             if (!returnValue) {

--- a/src/test/java/com/ghgande/j2mod/modbus/utils/TestUtils.java
+++ b/src/test/java/com/ghgande/j2mod/modbus/utils/TestUtils.java
@@ -27,6 +27,8 @@ import java.io.*;
 import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
@@ -46,9 +48,10 @@ public class TestUtils {
      * This method will extract the appropriate Modbus master tool into the
      * temp folder so that it can be used later
      *
+     * @return The temporary location of the Modbus master tool.
      * @throws Exception
      */
-    public static void loadModPollTool() throws Exception {
+    public static File loadModPollTool() throws Exception {
 
         // Load the resource from the library
 
@@ -66,125 +69,53 @@ public class TestUtils {
             exeName = "modpoll";
         }
 
-        // Check to see if we already have the library available
+        // Copy the native modpoll library to a temporary directory in the build workspace to facilitate
+        // execution on some platforms.
+        File tmpDir = Files.createTempDirectory(Paths.get("."), "modpoll-").toFile();
+        tmpDir.deleteOnExit();
 
-        File nativeFile = new File(getTemporaryDirectory(), exeName);
-        if (!nativeFile.exists()) {
+        File nativeFile = new File(tmpDir, exeName);
 
-            // Copy the library to the temporary folder
+        // Copy the library to the temporary folder
 
-            InputStream in = null;
-            String resourceName = String.format("/com/ghgande/j2mod/modbus/native/%s/%s", osName, exeName);
+        InputStream in = null;
+        String resourceName = String.format("/com/ghgande/j2mod/modbus/native/%s/%s", osName, exeName);
 
-            try {
-                in = SerialPort.class.getResourceAsStream(resourceName);
-                if (in == null) {
-                    throw new Exception(String.format("Cannot find resource [%s]", resourceName));
-                }
-                pipeInputToOutputStream(in, nativeFile, false);
+        try {
+        	in = SerialPort.class.getResourceAsStream(resourceName);
+        	if (in == null) {
+        		throw new Exception(String.format("Cannot find resource [%s]", resourceName));
+        	}
+        	pipeInputToOutputStream(in, nativeFile, false);
+        	nativeFile.deleteOnExit();
+        	
+        	// Set the correct privileges
 
-                // Set the correct privileges
-
-                if (!nativeFile.setWritable(true, true)) {
-                    logger.warn("Cannot set jSerialComm native library to be writable");
-                }
-                if (!nativeFile.setReadable(true, false)) {
-                    logger.warn("Cannot set jSerialComm native library to be readable");
-                }
-            }
-            catch (Exception e) {
-                throw new Exception(String.format("Cannot locate jSerialComm native library [%s] - %s", exeName, e.getMessage()));
-            }
-            finally {
-                if (in != null) {
-                    try {
-                        in.close();
-                    }
-                    catch (IOException e) {
-                        logger.error("Cannot close stream - {}", e.getMessage());
-                    }
-                }
-            }
+        	if (!nativeFile.setWritable(true, true)) {
+        		logger.warn("Cannot set modpoll native library to be writable");
+        	}
+        	if (!nativeFile.setReadable(true, false)) {
+        		logger.warn("Cannot set modpoll native library to be readable");
+        	}
+        	if (!nativeFile.setExecutable(true, false)) {
+        		logger.warn("Cannot set modpoll native library to be executable");
+        	}
         }
-    }
-
-    /**
-     * Returns a full path name of a suitable temporary filename
-     *
-     * @return String
-     */
-    public static String getTemporaryDirectory() {
-        return System.getProperty("java.io.tmpdir");
-    }
-
-    /**
-     * Returns a full path name of a suitable temporary filename
-     *
-     * @return File
-     */
-    public static File getTemporaryFile() {
-        return new File(getTemporaryFilename(null));
-    }
-
-    /**
-     * Returns a full path name of a suitable temporary filename using the
-     * extension provided.  If sExtension is null then .tmp is used
-     *
-     * @param extension Extension to give the file
-     *
-     * @return File
-     */
-    public static File getTemporaryFile(String extension) {
-        return new File(getTemporaryFilename(extension));
-    }
-
-    /**
-     * Returns a full path name of a suitable temporary filename
-     *
-     * @return String
-     */
-    public static String getTemporaryFilename() {
-        return getTemporaryFilename(null);
-    }
-
-    /**
-     * Returns a full path name of a suitable temporary filename using the
-     * extension provided.  If sExtension is null then .tmp is used
-     *
-     * @param extension Extension to give the file
-     *
-     * @return String
-     */
-    public static String getTemporaryFilename(String extension) {
-        return getTemporaryDirectory() + File.separator + getTemporaryFilenameOnly(extension);
-    }
-
-    /**
-     * Returns a temporary filename only using the extension if provided. if the provided value is null then .tmp is used
-     *
-     * @param extension Extension to give the file
-     *
-     * @return a {@link java.lang.String} object
-     */
-    public static String getTemporaryFilenameOnly(String extension) {
-        String returnValue;
-        if (extension != null) {
-            returnValue = getTemporaryName() + '.' + extension.trim();
+        catch (Exception e) {
+        	throw new Exception(String.format("Cannot locate modpoll native library [%s] - %s", exeName, e.getMessage()));
         }
-        else {
-            returnValue = getTemporaryName() + ".tmp";
+        finally {
+        	if (in != null) {
+        		try {
+        			in.close();
+        		}
+        		catch (IOException e) {
+        			logger.error("Cannot close stream - {}", e.getMessage());
+        		}
+        	}
         }
-
-        return returnValue;
-    }
-
-    /**
-     * Returns a temporary name which should be unique to this thread
-     *
-     * @return a {@link java.lang.String} object
-     */
-    public static String getTemporaryName() {
-        return "j2mode-" + Thread.currentThread().getId() + '-' + System.nanoTime();
+        
+        return nativeFile;
     }
 
     /**

--- a/src/test/java/com/ghgande/j2mod/modbus/utils/TestUtils.java
+++ b/src/test/java/com/ghgande/j2mod/modbus/utils/TestUtils.java
@@ -27,6 +27,8 @@ import java.io.*;
 import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
@@ -48,7 +50,7 @@ public class TestUtils {
      *
      * @throws Exception
      */
-    public static void loadModPollTool() throws Exception {
+    public static File loadModPollTool() throws Exception {
 
         // Load the resource from the library
 
@@ -66,125 +68,51 @@ public class TestUtils {
             exeName = "modpoll";
         }
 
-        // Check to see if we already have the library available
-
-        File nativeFile = new File(getTemporaryDirectory(), exeName);
-        if (!nativeFile.exists()) {
-
+        // Copy the modpoll utility to a temporary folder in the build workspace.
+        File tmpDir = Files.createTempDirectory(Paths.get("."), "modbus-").toFile();
+        tmpDir.deleteOnExit();
+        File nativeFile = new File(tmpDir, exeName);
+        
             // Copy the library to the temporary folder
 
-            InputStream in = null;
-            String resourceName = String.format("/com/ghgande/j2mod/modbus/native/%s/%s", osName, exeName);
+        InputStream in = null;
+        String resourceName = String.format("/com/ghgande/j2mod/modbus/native/%s/%s", osName, exeName);
 
-            try {
-                in = SerialPort.class.getResourceAsStream(resourceName);
-                if (in == null) {
-                    throw new Exception(String.format("Cannot find resource [%s]", resourceName));
-                }
-                pipeInputToOutputStream(in, nativeFile, false);
+        try {
+        	in = SerialPort.class.getResourceAsStream(resourceName);
+        	if (in == null) {
+        		throw new Exception(String.format("Cannot find resource [%s]", resourceName));
+        	}
+        	pipeInputToOutputStream(in, nativeFile, false);
+        	nativeFile.deleteOnExit();
 
-                // Set the correct privileges
+        	// Set the correct privileges
 
-                if (!nativeFile.setWritable(true, true)) {
-                    logger.warn("Cannot set jSerialComm native library to be writable");
-                }
-                if (!nativeFile.setReadable(true, false)) {
-                    logger.warn("Cannot set jSerialComm native library to be readable");
-                }
-            }
-            catch (Exception e) {
-                throw new Exception(String.format("Cannot locate jSerialComm native library [%s] - %s", exeName, e.getMessage()));
-            }
-            finally {
-                if (in != null) {
-                    try {
-                        in.close();
-                    }
-                    catch (IOException e) {
-                        logger.error("Cannot close stream - {}", e.getMessage());
-                    }
-                }
-            }
+        	if (!nativeFile.setWritable(true, true)) {
+        		logger.warn("Cannot set modpoll native library to be writable");
+        	}
+        	if (!nativeFile.setReadable(true, false)) {
+        		logger.warn("Cannot set modpoll native library to be readable");
+        	}
+        	if (!nativeFile.setExecutable(true, false)) {
+        		logger.warn("Cannot set modpoll native library to be executable");
+        	}
         }
-    }
-
-    /**
-     * Returns a full path name of a suitable temporary filename
-     *
-     * @return String
-     */
-    public static String getTemporaryDirectory() {
-        return System.getProperty("java.io.tmpdir");
-    }
-
-    /**
-     * Returns a full path name of a suitable temporary filename
-     *
-     * @return File
-     */
-    public static File getTemporaryFile() {
-        return new File(getTemporaryFilename(null));
-    }
-
-    /**
-     * Returns a full path name of a suitable temporary filename using the
-     * extension provided.  If sExtension is null then .tmp is used
-     *
-     * @param extension Extension to give the file
-     *
-     * @return File
-     */
-    public static File getTemporaryFile(String extension) {
-        return new File(getTemporaryFilename(extension));
-    }
-
-    /**
-     * Returns a full path name of a suitable temporary filename
-     *
-     * @return String
-     */
-    public static String getTemporaryFilename() {
-        return getTemporaryFilename(null);
-    }
-
-    /**
-     * Returns a full path name of a suitable temporary filename using the
-     * extension provided.  If sExtension is null then .tmp is used
-     *
-     * @param extension Extension to give the file
-     *
-     * @return String
-     */
-    public static String getTemporaryFilename(String extension) {
-        return getTemporaryDirectory() + File.separator + getTemporaryFilenameOnly(extension);
-    }
-
-    /**
-     * Returns a temporary filename only using the extension if provided. if the provided value is null then .tmp is used
-     *
-     * @param extension Extension to give the file
-     *
-     * @return a {@link java.lang.String} object
-     */
-    public static String getTemporaryFilenameOnly(String extension) {
-        String returnValue;
-        if (extension != null) {
-            returnValue = getTemporaryName() + '.' + extension.trim();
+        catch (Exception e) {
+        	throw new Exception(String.format("Cannot locate modpoll native library [%s] - %s", exeName, e.getMessage()));
         }
-        else {
-            returnValue = getTemporaryName() + ".tmp";
+        finally {
+        	if (in != null) {
+        		try {
+        			in.close();
+        		}
+        		catch (IOException e) {
+        			logger.error("Cannot close stream - {}", e.getMessage());
+        		}
+        	}
         }
-
-        return returnValue;
-    }
-
-    /**
-     * Returns a temporary name which should be unique to this thread
-     *
-     * @return a {@link java.lang.String} object
-     */
-    public static String getTemporaryName() {
-        return "j2mode-" + Thread.currentThread().getId() + '-' + System.nanoTime();
+        
+        return nativeFile;
     }
 
     /**

--- a/src/test/java/com/ghgande/j2mod/modbus/utils/TestUtils.java
+++ b/src/test/java/com/ghgande/j2mod/modbus/utils/TestUtils.java
@@ -27,8 +27,6 @@ import java.io.*;
 import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
@@ -50,7 +48,7 @@ public class TestUtils {
      *
      * @throws Exception
      */
-    public static File loadModPollTool() throws Exception {
+    public static void loadModPollTool() throws Exception {
 
         // Load the resource from the library
 
@@ -68,51 +66,125 @@ public class TestUtils {
             exeName = "modpoll";
         }
 
-        // Copy the modpoll utility to a temporary folder in the build workspace.
-        File tmpDir = Files.createTempDirectory(Paths.get("."), "modbus-").toFile();
-        tmpDir.deleteOnExit();
-        File nativeFile = new File(tmpDir, exeName);
-        
+        // Check to see if we already have the library available
+
+        File nativeFile = new File(getTemporaryDirectory(), exeName);
+        if (!nativeFile.exists()) {
+
             // Copy the library to the temporary folder
 
-        InputStream in = null;
-        String resourceName = String.format("/com/ghgande/j2mod/modbus/native/%s/%s", osName, exeName);
+            InputStream in = null;
+            String resourceName = String.format("/com/ghgande/j2mod/modbus/native/%s/%s", osName, exeName);
 
-        try {
-        	in = SerialPort.class.getResourceAsStream(resourceName);
-        	if (in == null) {
-        		throw new Exception(String.format("Cannot find resource [%s]", resourceName));
-        	}
-        	pipeInputToOutputStream(in, nativeFile, false);
-        	nativeFile.deleteOnExit();
+            try {
+                in = SerialPort.class.getResourceAsStream(resourceName);
+                if (in == null) {
+                    throw new Exception(String.format("Cannot find resource [%s]", resourceName));
+                }
+                pipeInputToOutputStream(in, nativeFile, false);
 
-        	// Set the correct privileges
+                // Set the correct privileges
 
-        	if (!nativeFile.setWritable(true, true)) {
-        		logger.warn("Cannot set modpoll native library to be writable");
-        	}
-        	if (!nativeFile.setReadable(true, false)) {
-        		logger.warn("Cannot set modpoll native library to be readable");
-        	}
-        	if (!nativeFile.setExecutable(true, false)) {
-        		logger.warn("Cannot set modpoll native library to be executable");
-        	}
+                if (!nativeFile.setWritable(true, true)) {
+                    logger.warn("Cannot set jSerialComm native library to be writable");
+                }
+                if (!nativeFile.setReadable(true, false)) {
+                    logger.warn("Cannot set jSerialComm native library to be readable");
+                }
+            }
+            catch (Exception e) {
+                throw new Exception(String.format("Cannot locate jSerialComm native library [%s] - %s", exeName, e.getMessage()));
+            }
+            finally {
+                if (in != null) {
+                    try {
+                        in.close();
+                    }
+                    catch (IOException e) {
+                        logger.error("Cannot close stream - {}", e.getMessage());
+                    }
+                }
+            }
         }
-        catch (Exception e) {
-        	throw new Exception(String.format("Cannot locate modpoll native library [%s] - %s", exeName, e.getMessage()));
+    }
+
+    /**
+     * Returns a full path name of a suitable temporary filename
+     *
+     * @return String
+     */
+    public static String getTemporaryDirectory() {
+        return System.getProperty("java.io.tmpdir");
+    }
+
+    /**
+     * Returns a full path name of a suitable temporary filename
+     *
+     * @return File
+     */
+    public static File getTemporaryFile() {
+        return new File(getTemporaryFilename(null));
+    }
+
+    /**
+     * Returns a full path name of a suitable temporary filename using the
+     * extension provided.  If sExtension is null then .tmp is used
+     *
+     * @param extension Extension to give the file
+     *
+     * @return File
+     */
+    public static File getTemporaryFile(String extension) {
+        return new File(getTemporaryFilename(extension));
+    }
+
+    /**
+     * Returns a full path name of a suitable temporary filename
+     *
+     * @return String
+     */
+    public static String getTemporaryFilename() {
+        return getTemporaryFilename(null);
+    }
+
+    /**
+     * Returns a full path name of a suitable temporary filename using the
+     * extension provided.  If sExtension is null then .tmp is used
+     *
+     * @param extension Extension to give the file
+     *
+     * @return String
+     */
+    public static String getTemporaryFilename(String extension) {
+        return getTemporaryDirectory() + File.separator + getTemporaryFilenameOnly(extension);
+    }
+
+    /**
+     * Returns a temporary filename only using the extension if provided. if the provided value is null then .tmp is used
+     *
+     * @param extension Extension to give the file
+     *
+     * @return a {@link java.lang.String} object
+     */
+    public static String getTemporaryFilenameOnly(String extension) {
+        String returnValue;
+        if (extension != null) {
+            returnValue = getTemporaryName() + '.' + extension.trim();
         }
-        finally {
-        	if (in != null) {
-        		try {
-        			in.close();
-        		}
-        		catch (IOException e) {
-        			logger.error("Cannot close stream - {}", e.getMessage());
-        		}
-        	}
+        else {
+            returnValue = getTemporaryName() + ".tmp";
         }
-        
-        return nativeFile;
+
+        return returnValue;
+    }
+
+    /**
+     * Returns a temporary name which should be unique to this thread
+     *
+     * @return a {@link java.lang.String} object
+     */
+    public static String getTemporaryName() {
+        return "j2mode-" + Thread.currentThread().getId() + '-' + System.nanoTime();
     }
 
     /**


### PR DESCRIPTION
The unit tests did not complete successfully on Linux because on some Linux distributions the /tmp-folder does not have execute privileges. This is mitigated by creating a temporary folder (which will be automatically deleted when the JVM stops) in the build folder.