### PR TITLE
Xm/rtutransport

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+	<additionalparam>-Xdoclint:none</additionalparam>
     </properties>
 
     <developers>

--- a/src/main/java/com/ghgande/j2mod/modbus/io/FastByteArrayInputStream.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/io/FastByteArrayInputStream.java
@@ -39,6 +39,7 @@ public class FastByteArrayInputStream extends InputStream {
      * Number of bytes in the input buffer.
      */
     protected int count;
+
     /**
      * Actual position pointer into the input buffer.
      */
@@ -118,6 +119,8 @@ public class FastByteArrayInputStream extends InputStream {
     public int available() {
         return count - pos;
     }
+
+    public int getCount() { return count; }
 
     public void mark(int readlimit) {
         logger.debug("mark()");

--- a/src/main/java/com/ghgande/j2mod/modbus/io/ModbusRTUTCPTransport.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/io/ModbusRTUTCPTransport.java
@@ -47,17 +47,18 @@ public class ModbusRTUTCPTransport extends ModbusTCPTransport {
             dataOutputStream.flush();
             logger.debug("Sent: {}", ModbusUtil.toHex(byteOutputStream.toByteArray()));
             // write more sophisticated exception handling
-        } catch (SocketException ex) {
+        } catch (SocketException ex1) {
             if (master != null && !master.isConnected()) {
                 try {
                     master.connect();
                 }
                 catch (Exception e) {
-                    throw new ModbusIOException("I/O exception - failed to write - %s", ex.getMessage(), ex);
+                    // Do nothing.
                 }
             }
-        } catch (Exception ex) {
-            throw new ModbusIOException("I/O exception - failed to write - %s", ex.getMessage(), ex);
+            throw new ModbusIOException("I/O exception - failed to write", ex1);
+        } catch (Exception ex2) {
+            throw new ModbusIOException("I/O exception - failed to write", ex2);
         }
     }
 }

--- a/src/main/java/com/ghgande/j2mod/modbus/io/ModbusRTUTCPTransport.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/io/ModbusRTUTCPTransport.java
@@ -1,0 +1,63 @@
+package com.ghgande.j2mod.modbus.io;
+
+import com.ghgande.j2mod.modbus.ModbusIOException;
+import com.ghgande.j2mod.modbus.msg.ModbusMessage;
+import com.ghgande.j2mod.modbus.util.ModbusUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.net.SocketException;
+
+/**
+ * Created by axuan on 06/06/16.
+ */
+public class ModbusRTUTCPTransport extends ModbusTCPTransport {
+
+    private static final Logger logger = LoggerFactory.getLogger(ModbusRTUTCPTransport.class);
+
+    public ModbusRTUTCPTransport() {
+        // RTU over TCP is headless by default
+        setHeadless();
+    }
+
+    @Override
+    public void writeMessage(ModbusMessage msg) throws ModbusIOException {
+        try {
+            byte message[] = msg.getMessage();
+
+            byteOutputStream.reset();
+            if (!headless) {
+                byteOutputStream.writeShort(msg.getTransactionID());
+                byteOutputStream.writeShort(msg.getProtocolID());
+                byteOutputStream.writeShort((message != null ? message.length : 0) + 2);
+            }
+            byteOutputStream.writeByte(msg.getUnitID());
+            byteOutputStream.writeByte(msg.getFunctionCode());
+            if (message != null && message.length > 0) {
+                byteOutputStream.write(message);
+            }
+
+            // Add CRC for RTU over TCP
+            int len = byteOutputStream.size();
+            int[] crc = ModbusUtil.calculateCRC(byteOutputStream.getBuffer(), 0, len);
+            byteOutputStream.writeByte(crc[0]);
+            byteOutputStream.writeByte(crc[1]);
+
+            dataOutputStream.write(byteOutputStream.toByteArray());
+            dataOutputStream.flush();
+            logger.debug("Sent: {}", ModbusUtil.toHex(byteOutputStream.toByteArray()));
+            // write more sophisticated exception handling
+        } catch (SocketException ex) {
+            if (master != null && !master.isConnected()) {
+                try {
+                    master.connect();
+                }
+                catch (Exception e) {
+                    throw new ModbusIOException("I/O exception - failed to write - %s", ex.getMessage(), ex);
+                }
+            }
+        } catch (Exception ex) {
+            throw new ModbusIOException("I/O exception - failed to write - %s", ex.getMessage(), ex);
+        }
+    }
+}

--- a/src/main/java/com/ghgande/j2mod/modbus/io/ModbusTCPTransport.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/io/ModbusTCPTransport.java
@@ -50,6 +50,9 @@ public class ModbusTCPTransport extends AbstractModbusTransport {
     private TCPMasterConnection master = null;
     private boolean headless = false; // Some TCP implementations are.
 
+    public ModbusTCPTransport() {
+    }
+
     /**
      * Constructs a new <tt>ModbusTransport</tt> instance, for a given
      * <tt>Socket</tt>.

--- a/src/main/java/com/ghgande/j2mod/modbus/io/ModbusTCPTransport.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/io/ModbusTCPTransport.java
@@ -42,13 +42,13 @@ public class ModbusTCPTransport extends AbstractModbusTransport {
     private static final Logger logger = LoggerFactory.getLogger(ModbusTCPTransport.class);
 
     // instance attributes
-    private DataInputStream dataInputStream; // input stream
-    private DataOutputStream dataOutputStream; // output stream
-    private final BytesInputStream byteInputStream = new BytesInputStream(Modbus.MAX_MESSAGE_LENGTH + 6);
-    private final BytesOutputStream byteOutputStream = new BytesOutputStream(Modbus.MAX_MESSAGE_LENGTH + 6); // write frames
-    private Socket socket = null;
-    private TCPMasterConnection master = null;
-    private boolean headless = false; // Some TCP implementations are.
+    protected DataInputStream dataInputStream; // input stream
+    protected DataOutputStream dataOutputStream; // output stream
+    protected final BytesInputStream byteInputStream = new BytesInputStream(Modbus.MAX_MESSAGE_LENGTH + 6);
+    protected final BytesOutputStream byteOutputStream = new BytesOutputStream(Modbus.MAX_MESSAGE_LENGTH + 6); // write frames
+    protected Socket socket = null;
+    protected TCPMasterConnection master = null;
+    protected boolean headless = false; // Some TCP implementations are.
 
     public ModbusTCPTransport() {
     }

--- a/src/main/java/com/ghgande/j2mod/modbus/net/TCPMasterConnection.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/net/TCPMasterConnection.java
@@ -71,11 +71,11 @@ public class TCPMasterConnection {
      */
     private void prepareTransport() throws IOException {
         if (transport == null) {
-            logger.trace("prepareTransport() -> using standard TCP transport."); // xmight edit
+            logger.trace("prepareTransport() -> using standard TCP transport.");
             transport = new ModbusTCPTransport(socket);
         }
         else {
-            logger.trace("prepareTransport() -> using preset transport. ({})", transport.getClass().getSimpleName()); // xmight edit
+            logger.trace("prepareTransport() -> using custom transport: {}", transport.getClass().getSimpleName());
             transport.setSocket(socket);
         }
     }
@@ -108,16 +108,14 @@ public class TCPMasterConnection {
      */
     public synchronized boolean isConnected() {
         if (connected && socket != null) {
-            if (!socket.isConnected() || socket.isClosed()
-                    || socket.isInputShutdown()
-                    || socket.isOutputShutdown()) {
+            if (!socket.isConnected() || socket.isClosed() || socket.isInputShutdown() || socket.isOutputShutdown()) {
                 try {
                     socket.close();
+                } catch (IOException e) {
+                    logger.error("Socket exception", e);
+                } finally {
+                    connected = false;
                 }
-                catch (IOException e) {
-                    // Blah.
-                }
-                connected = false;
             }
             else {
                 /*
@@ -163,11 +161,11 @@ public class TCPMasterConnection {
         if (connected) {
             try {
                 transport.close();
+            } catch (IOException ex) {
+                logger.debug("close()", ex);
+            } finally {
+                connected = false;
             }
-            catch (IOException ex) {
-                logger.debug("close()");
-            }
-            connected = false;
         }
     }
 

--- a/src/main/java/com/ghgande/j2mod/modbus/net/TCPMasterConnection.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/net/TCPMasterConnection.java
@@ -71,9 +71,11 @@ public class TCPMasterConnection {
      */
     private void prepareTransport() throws IOException {
         if (transport == null) {
+            logger.trace("prepareTransport() -> using standard TCP transport."); // xmight edit
             transport = new ModbusTCPTransport(socket);
         }
         else {
+            logger.trace("prepareTransport() -> using preset transport. ({})", transport.getClass().getSimpleName()); // xmight edit
             transport.setSocket(socket);
         }
     }


### PR DESCRIPTION
Created a proper transport for RTU over TCP. Using J2mod's ModbusTCPTransport with setHeadless() does not result in successful transactions because the CRC is omitted in writeMessage();

Other changes:

-Disable doclint. Java 8 users get an exception when generating javadoc due to Java 8's stricter rules.
-Very basic exception handling changes. Actually, I removed most of my changes to avoid adding confusion here, but will make exception handling PRs later.