### PR TITLE
Ignore TCP server accept timeout exception

### DIFF
--- a/src/main/java/com/ghgande/j2mod/modbus/net/ModbusTCPListener.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/net/ModbusTCPListener.java
@@ -117,7 +117,12 @@ public class ModbusTCPListener extends AbstractModbusListener {
             // parallel logins
             listening = true;
             while (listening) {
-                Socket incoming = serverSocket.accept();
+                Socket incoming;
+                try {
+                    incoming = serverSocket.accept();
+                } catch (SocketTimeoutException e) {
+                    continue;
+                }
                 logger.debug("Making new connection {}", incoming.toString());
                 if (listening) {
                     threadPool.execute(new TCPConnectionHandler(this, new TCPSlaveConnection(incoming)));


### PR DESCRIPTION
There is a problem that after 5 seconds, TCP server fails. It is just because `accept` generates `SocketTimeoutException` after timeout. I is false positive exception and it should be ignored.