### PR TITLE
Adds setRetries and setCheckingValidity services into ModbusTCPMaster

### DIFF
--- a/src/main/java/com/ghgande/j2mod/modbus/facade/ModbusTCPMaster.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/facade/ModbusTCPMaster.java
@@ -144,6 +144,34 @@ public class ModbusTCPMaster extends AbstractModbusMaster {
         }
     }
 
+    
+    /**
+     * Set the amount of retries for opening
+     * the connection for executing the transaction.
+     * <p>
+     *
+     * @param retries the amount of retries as <tt>int</tt>.
+     */
+    public void setRetries( int retries )
+    {
+    	  if (transaction != null) {
+              ((ModbusTCPTransaction)transaction).setRetries(retries);
+          }
+    }
+    
+    /**
+     * Sets the flag that controls whether the
+     * validity of a transaction will be checked.
+     * <p>
+     *
+     * @param b true if checking validity, false otherwise.
+     */
+    public void setCheckingValidity(boolean b) {
+  	  if (transaction != null) {
+          ((ModbusTCPTransaction)transaction).setCheckingValidity(b);
+      }
+    }
+    
     @Override
     public void setTimeout(int timeout) {
         super.setTimeout(timeout);

--- a/src/main/java/com/ghgande/j2mod/modbus/io/ModbusTCPTransaction.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/io/ModbusTCPTransaction.java
@@ -144,7 +144,7 @@ public class ModbusTCPTransaction extends ModbusTransaction {
                         }
                     }
                 } while (response != null &&
-                        (!isCheckingValidity() || (request.getTransactionID() != 0 && request.getTransactionID() != response.getTransactionID())) &&
+                        (isCheckingValidity() && (request.getTransactionID() != 0 && request.getTransactionID() != response.getTransactionID())) &&
                         ++retryCounter < retryLimit);
 
                 if (retryCounter >= retryLimit) {


### PR DESCRIPTION
facade class.
Correction in ModbusTCPTransaction: when checkingValidity was false,
execute method loops until retry number elapsed.