### PR TITLE
Increased maximum queue length for incoming connections.

### DIFF
--- a/src/main/java/com/ghgande/j2mod/modbus/net/ModbusTCPListener.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/net/ModbusTCPListener.java
@@ -96,7 +96,7 @@ public class ModbusTCPListener extends AbstractModbusListener {
              * attacks via massive parallel program logins can probably be
              * prevented.
              */
-            int floodProtection = 5;
+            int floodProtection = 50;
             serverSocket = new ServerSocket(port, floodProtection, address);
             serverSocket.setSoTimeout(timeout);
             logger.debug("Listening to {} (Port {})", serverSocket.toString(), port);


### PR DESCRIPTION
Adjusted maximum queue length for incoming connections from 5 to 50 when instantiating ServerSocket in ModbusTCPListener.

This was bothering us while unit testing one of our application which uses the j2mod-library.

The new maximum queue length (or "flood protection" as it is named in the source code) of 50 was actually chosen as the default maximum queue length because this is the default value mentioned in the (Oracle) Javadoc of java.net.ServerSocket.