### PR TITLE
Added getConnection() method for ModbusSerialMaster

### DIFF
--- a/src/main/java/com/ghgande/j2mod/modbus/facade/ModbusSerialMaster.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/facade/ModbusSerialMaster.java
@@ -66,6 +66,10 @@ public class ModbusSerialMaster extends AbstractModbusMaster {
         }
     }
 
+    public AbstractSerialConnection getConnection() {
+        return connection;
+    }
+
     /**
      * Connects this <tt>ModbusSerialMaster</tt> with the slave.
      *


### PR DESCRIPTION
Having public access to `AbstractSerialConnection connection` would give helpful information, such as: `isOpen()`, `getDescriptivePortName()`, etc.