### PR TITLE
TCP Connection idle timeout

### DIFF
--- a/src/main/java/com/ghgande/j2mod/modbus/io/ModbusTCPTransport.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/io/ModbusTCPTransport.java
@@ -50,11 +50,13 @@ public class ModbusTCPTransport extends AbstractModbusTransport {
     protected Socket socket = null;
     protected TCPMasterConnection master = null;
     private boolean headless = false; // Some TCP implementations are.
+    private long lastActivityTs;  // System.nanoTime() of last transportation
 
     /**
      * Default constructor
      */
     public ModbusTCPTransport() {
+        lastActivityTs = System.nanoTime();
     }
 
     /**
@@ -65,6 +67,8 @@ public class ModbusTCPTransport extends AbstractModbusTransport {
      * @param socket the <tt>Socket</tt> used for message transport.
      */
     public ModbusTCPTransport(Socket socket) {
+        lastActivityTs = System.nanoTime();
+        
         try {
             setSocket(socket);
             socket.setSoTimeout(timeout);
@@ -132,6 +136,14 @@ public class ModbusTCPTransport extends AbstractModbusTransport {
         }
     }
 
+    /** 
+     * @return last activity timestamp for the transport (System.nanoTime() timestamp)
+     * @see System#nanoTime() 
+     */
+    public long getLastActivityTs() {
+        return lastActivityTs;
+    }
+
     @Override
     public void close() throws IOException {
         dataInputStream.close();
@@ -161,6 +173,8 @@ public class ModbusTCPTransport extends AbstractModbusTransport {
 
     @Override
     public ModbusRequest readRequest(AbstractModbusListener listener) throws ModbusIOException {
+        lastActivityTs = System.nanoTime();
+        
         ModbusRequest req;
         try {
             byteInputStream.reset();
@@ -240,6 +254,8 @@ public class ModbusTCPTransport extends AbstractModbusTransport {
 
     @Override
     public ModbusResponse readResponse() throws ModbusIOException {
+        lastActivityTs = System.nanoTime();
+        
         try {
             ModbusResponse response;
 
@@ -355,6 +371,8 @@ public class ModbusTCPTransport extends AbstractModbusTransport {
      *                           this <tt>ModbusTransport</tt>.
      */
     void writeMessage(ModbusMessage msg, boolean useRtuOverTcp) throws ModbusIOException {
+        lastActivityTs = System.nanoTime();
+        
         try {
             if (logger.isDebugEnabled()) {
                 logger.debug("Sending: {}", msg.getHexMessage());

--- a/src/main/java/com/ghgande/j2mod/modbus/net/TCPSlaveConnection.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/net/TCPSlaveConnection.java
@@ -97,6 +97,15 @@ public class TCPSlaveConnection {
         return transport;
     }
 
+    /** 
+     * @return last activity timestamp of a connection
+     * @see ModbusTCPTransport#getLastActivityTs() 
+     * @see System#nanoTime() 
+     */
+    public long getLastActivityTs() {
+        return transport.getLastActivityTs();
+    }
+    
     /**
      * Prepares the associated <tt>ModbusTransport</tt> of this
      * <tt>TCPMasterConnection</tt> for use.

--- a/src/main/java/com/ghgande/j2mod/modbus/slave/ModbusSlave.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/slave/ModbusSlave.java
@@ -58,7 +58,7 @@ public class ModbusSlave {
      * @throws ModbusException If a problem occurs e.g. port already in use
      */
     protected ModbusSlave(int port, int poolSize, boolean useRtuOverTcp) throws ModbusException {
-        this(ModbusSlaveType.TCP, null, port, poolSize, null, useRtuOverTcp);
+        this(ModbusSlaveType.TCP, null, port, poolSize, null, useRtuOverTcp, 0);
     }
 
     /**
@@ -70,8 +70,8 @@ public class ModbusSlave {
      * @param useRtuOverTcp True if the RTU protocol should be used over TCP
      * @throws ModbusException If a problem occurs e.g. port already in use
      */
-    protected ModbusSlave(InetAddress address, int port, int poolSize, boolean useRtuOverTcp) throws ModbusException {
-        this(ModbusSlaveType.TCP, address, port, poolSize, null, useRtuOverTcp);
+    protected ModbusSlave(InetAddress address, int port, int poolSize, boolean useRtuOverTcp, int maxIdleSeconds) throws ModbusException {
+        this(ModbusSlaveType.TCP, address, port, poolSize, null, useRtuOverTcp, maxIdleSeconds);
     }
 
     /**
@@ -82,7 +82,7 @@ public class ModbusSlave {
      * @throws ModbusException If a problem occurs e.g. port already in use
      */
     protected ModbusSlave(int port, boolean useRtuOverTcp) throws ModbusException {
-        this(ModbusSlaveType.UDP, null, port, 0, null, useRtuOverTcp);
+        this(ModbusSlaveType.UDP, null, port, 0, null, useRtuOverTcp, 0);
     }
 
     /**
@@ -94,7 +94,7 @@ public class ModbusSlave {
      * @throws ModbusException If a problem occurs e.g. port already in use
      */
     protected ModbusSlave(InetAddress address, int port, boolean useRtuOverTcp) throws ModbusException {
-        this(ModbusSlaveType.UDP, address, port, 0, null, useRtuOverTcp);
+        this(ModbusSlaveType.UDP, address, port, 0, null, useRtuOverTcp, 0);
     }
 
     /**
@@ -104,20 +104,21 @@ public class ModbusSlave {
      * @throws ModbusException If a problem occurs e.g. port already in use
      */
     protected ModbusSlave(SerialParameters serialParams) throws ModbusException {
-        this(ModbusSlaveType.SERIAL, null, 0, 0, serialParams, false);
+        this(ModbusSlaveType.SERIAL, null, 0, 0, serialParams, false, 0);
     }
 
     /**
      * Creates an appropriate type of listener
      *
-     * @param type          Type of slave to create
-     * @param address       IP address to listen on
-     * @param port          Port to listen on if IP type
-     * @param poolSize      Pool size for TCP slaves
-     * @param serialParams  Serial parameters for serial type slaves
-     * @param useRtuOverTcp True if the RTU protocol should be used over TCP
+     * @param type              Type of slave to create
+     * @param address           IP address to listen on
+     * @param port              Port to listen on if IP type
+     * @param poolSize          Pool size for TCP slaves
+     * @param serialParams      Serial parameters for serial type slaves
+     * @param useRtuOverTcp     True if the RTU protocol should be used over TCP
+     * @param maxIdleSeconds    Maximum idle seconds for TCP connection
      */
-    private ModbusSlave(ModbusSlaveType type, InetAddress address, int port, int poolSize, SerialParameters serialParams, boolean useRtuOverTcp) {
+    private ModbusSlave(ModbusSlaveType type, InetAddress address, int port, int poolSize, SerialParameters serialParams, boolean useRtuOverTcp, int maxIdleSeconds) {
         this.type = type == null ? ModbusSlaveType.TCP : type;
         this.port = port;
         this.serialParams = serialParams;
@@ -129,7 +130,9 @@ public class ModbusSlave {
             listener = new ModbusUDPListener();
         }
         else if (this.type.is(ModbusSlaveType.TCP)) {
-            listener = new ModbusTCPListener(poolSize, useRtuOverTcp);
+            ModbusTCPListener tcpListener = new ModbusTCPListener(poolSize, useRtuOverTcp);
+            tcpListener.setMaxIdleSeconds(maxIdleSeconds);            
+            listener = tcpListener;            
         }
         else {
             listener = new ModbusSerialListener(serialParams);

--- a/src/main/java/com/ghgande/j2mod/modbus/slave/ModbusSlaveFactory.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/slave/ModbusSlaveFactory.java
@@ -81,12 +81,28 @@ public class ModbusSlaveFactory {
      * @throws ModbusException If a problem occurs e.g. port already in use
      */
     public static synchronized ModbusSlave createTCPSlave(InetAddress address, int port, int poolSize, boolean useRtuOverTcp) throws ModbusException {
+        return ModbusSlaveFactory.createTCPSlave(address, port, poolSize, useRtuOverTcp, 0);
+    }
+
+    /**
+     * Creates a TCP modbus slave or returns the one already allocated to this port
+     *
+     * @param address           IP address to listen on
+     * @param port              Port to listen on
+     * @param poolSize          Pool size of listener threads
+     * @param useRtuOverTcp     True if the RTU protocol should be used over TCP
+     * @param maxIdleSeconds    Maximum idle seconds for TCP connection
+     * @return new or existing TCP modbus slave associated with the port
+     *
+     * @throws ModbusException If a problem occurs e.g. port already in use
+     */
+    public static synchronized ModbusSlave createTCPSlave(InetAddress address, int port, int poolSize, boolean useRtuOverTcp, int maxIdleSeconds) throws ModbusException {
         String key = ModbusSlaveType.TCP.getKey(port);
         if (slaves.containsKey(key)) {
             return slaves.get(key);
         }
         else {
-            ModbusSlave slave = new ModbusSlave(address, port, poolSize, useRtuOverTcp);
+            ModbusSlave slave = new ModbusSlave(address, port, poolSize, useRtuOverTcp, maxIdleSeconds);
             slaves.put(key, slave);
             return slave;
         }


### PR DESCRIPTION
Hi Steve,

First, thank you very much for working on j2mod. I've been using original jamod for quite a while in my projects and I was always worried about its error handling / etc being a bit "childish". j2mod code looks much better.

Still, there is an issue.
My Modbus/TCP slaves sometimes get unresponsive - it will accept incoming connections but will never respond anything. I tracked it to be the cases where connection suddenly drops. For examples, master devices being abruptly powered off of a LAN cable being disconnected.

TCP connection will not detect any timeouts if it is not actively sending any data. So, if LAN cable is disconnected _between_ requests, ModbusTCPTransport will simply hang in Socket.read(), waiting for data which will never arrive and occupying a thread in a thread pool. Eventually thread pool becomes depleted and slave doesn't process any more requests.

There is a couple of bugs in JDK (https://bugs.java.com/bugdatabase/view_bug.do?bug_id=8075484 and relates), which are "fixed" but are still reproducable on some machines (I've been using 8u201 on CentOS 6 and it is still there).

Please review this pull request. 
I've added a watchdog timer for TCP connection, which closes the connection if there is no activity within a given timeframe. This works as a safety net - if master dies, a connection will eventually be closed and release the thread in thread pool.

Please feel free to request any changes, if proposed changes doesn't suite your design (it seems to me that TCPConnectionHandler is a right place for the watchdog, but I'm not sure), I will do them.

Sincerely, Anatoly

P.S. I couldn't find a documentation on building / running unit tests, please would you point me there, if it exists.
Some tests (TestModbusTCPExternalRead, for example) seems to rely on some external tool (?) and I was unable to run them.