### PR TITLE
Added equals & hashcode method to ModbusTCPMaster & TCPMasterConnection

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,5 +21,5 @@ For the best chance of getting your changes incorporated into the code base, ple
 
 * Follow the coding style already established - same indentation, line spacing, naming convention etc.
 * ALWAYS provide JUnit tests for your changes - copy existing ones, modify the current versions but there must be supporting unit tests
-* Thorougly comment your code and provide proper JavaDoc headers, even for private methods
+* Thoroughly comment your code and provide proper JavaDoc headers, even for private methods
 

--- a/src/main/java/com/ghgande/j2mod/modbus/facade/ModbusTCPMaster.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/facade/ModbusTCPMaster.java
@@ -21,6 +21,7 @@ import com.ghgande.j2mod.modbus.io.ModbusTCPTransaction;
 import com.ghgande.j2mod.modbus.net.TCPMasterConnection;
 
 import java.net.InetAddress;
+import java.net.SocketException;
 import java.net.UnknownHostException;
 
 /**
@@ -193,5 +194,33 @@ public class ModbusTCPMaster extends AbstractModbusMaster {
     @Override
     public boolean isConnected() {
         return connection != null && connection.isConnected();
+    }
+
+    /**
+     * A {@link ModbusTCPMaster} is equal if the underlying {@link TCPMasterConnection} is equal. There can't be 2
+     * un-identical {@link ModbusTCPMaster}s with the same connection at the same time. One of the two, will raise a
+     * {@link SocketException} if you start both at the same time, since the socket is only usable by exactly on entity
+     *
+     * @param obj Entity to be checked for equality
+     * @return <code>true</code> if object is equal, <code>false</code> otherwise
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null || ModbusTCPMaster.class != obj.getClass()) {
+            return false;
+        } else {
+            ModbusTCPMaster other = (ModbusTCPMaster) obj;
+            return this == obj || this.connection.equals(other.connection);
+        }
+    }
+
+    /**
+     * The unique value of the {@link ModbusTCPMaster} is calculated from the unique value of the {@link TCPMasterConnection}
+     *
+     * @return Unique integer hash code
+     */
+    @Override
+    public int hashCode() {
+        return connection.hashCode();
     }
 }

--- a/src/main/java/com/ghgande/j2mod/modbus/net/TCPMasterConnection.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/net/TCPMasterConnection.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.util.Objects;
 
 /**
  * Class that implements a TCPMasterConnection.
@@ -334,5 +335,34 @@ public class TCPMasterConnection {
         if (isConnected()) {
             prepareTransport(useRtuOverTcp);
         }
+    }
+
+    /**
+     * A {@link TCPMasterConnection} is equal if {@link InetAddress} &amp; port are equal. There is no way how two
+     * different {@link TCPMasterConnection}s can use the same {@link Socket} at the same time, therefore this is good
+     * enough for an equality test
+     *
+     * @param obj Entity to be checked for equality
+     * @return <code>true</code> if object is equal, <code>false</code> otherwise
+     */
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null || TCPMasterConnection.class != obj.getClass()) {
+            return false;
+        } else {
+            TCPMasterConnection other = (TCPMasterConnection) obj;
+            return this == obj || this.address.equals(other.address) && this.port == other.port;
+        }
+    }
+
+    /**
+     * The unique value of the {@link TCPMasterConnection} is calculated from the unique values of the
+     * {@link InetAddress} &amp; port
+     *
+     * @return Unique integer hash code
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(address, port);
     }
 }

--- a/src/test/java/com/ghgande/j2mod/modbus/TestModbusTCPMasterEquality.java
+++ b/src/test/java/com/ghgande/j2mod/modbus/TestModbusTCPMasterEquality.java
@@ -1,0 +1,51 @@
+package com.ghgande.j2mod.modbus;
+
+import com.ghgande.j2mod.modbus.facade.ModbusTCPMaster;
+import com.ghgande.j2mod.modbus.utils.AbstractTestModbusTCPMaster;
+import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.*;
+
+/**
+ * Testing class for {@link ModbusTCPMaster#equals} &amp; {@link ModbusTCPMaster#hashCode} methods
+ */
+public class TestModbusTCPMasterEquality extends AbstractTestModbusTCPMaster {
+
+    private static final Logger logger = LoggerFactory.getLogger(AbstractTestModbusTCPMaster.class);
+    public static final String LOCALHOST_2 = "127.0.0.2";
+    public static final int PORT_2 = 2503;
+    protected static ModbusTCPMaster master_2, master_3;
+
+    @Test
+    public void testEquality() {
+        master_2 = new ModbusTCPMaster(LOCALHOST_2, PORT);
+        master_3 = new ModbusTCPMaster(LOCALHOST, PORT_2);
+
+        assertThat("2 unequal Modbus TCP masters identified as equal", master, not(equalTo(master_2)));
+        assertThat("2 unequal Modbus TCP masters identified as equal", master, not(equalTo(master_3)));
+        assertThat("2 unequal Modbus TCP masters identified as equal", master_2, not(equalTo(master_3)));
+
+        assertThat("2 equal Modbus TCP masters identified as unequal", master, equalTo(master));
+        assertThat("2 equal Modbus TCP masters identified as unequal", master_2, equalTo(master_2));
+        assertThat("2 equal Modbus TCP masters identified as unequal", master_3, equalTo(master_3));
+    }
+
+    @Test
+    public void testHashCode() {
+        master_2 = new ModbusTCPMaster(LOCALHOST_2, PORT);
+        master_3 = new ModbusTCPMaster(LOCALHOST, PORT_2);
+
+        assertThat("2 unequal Modbus TCP masters had same hash code", master.hashCode(), not(equalTo(master_2.hashCode())));
+        assertThat("2 unequal Modbus TCP masters had same hash code", master.hashCode(), not(equalTo(master_3.hashCode())));
+        assertThat("2 unequal Modbus TCP masters had same hash code", master_2.hashCode(), not(equalTo(master_3.hashCode())));
+
+        assertThat("2 equal Modbus TCP masters had NOT same hash code", master.hashCode(), equalTo(master.hashCode()));
+        assertThat("2 equal Modbus TCP masters had NOT same hash code", master_2.hashCode(), equalTo(master_2.hashCode()));
+        assertThat("2 equal Modbus TCP masters had NOT same hash code", master_3.hashCode(), equalTo(master_3.hashCode()));
+    }
+}


### PR DESCRIPTION
Hi,
I implemented equals & hash code methods for `ModbusTCPMaster`. The problem here is, that your "facade" has not relly anything that i can work with to identify unique entities. That is why I have now gone the route via the `TCPMasterConnection`. A master is now identified through his connection. If it is not the same connection, then it cannot be the same master.
The connection itself, I identify by the address & the port. A connection is exactly the same, if it targets the same IP address & the with the same port.
The problem here now is that you can theoretically create multiple masters with the same address & port. These would then be handled as identical when you call the equals-method on them. Same goes for hashcode-method.

Oh..., and one small typo in your `CONTRIBUTING.md`