### PR TITLE
modbus slave factory getSlave fix

### DIFF
--- a/src/main/java/com/ghgande/j2mod/modbus/slave/ModbusSlaveType.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/slave/ModbusSlaveType.java
@@ -49,4 +49,17 @@ public enum ModbusSlaveType {
     public String getKey(int port) {
         return toString() + port;
     }
+
+    /**
+     * Returns a unique key for this port and type
+     *
+     * @param port Port number
+     * @return Unique key
+     */
+    public String getKey(String port) {
+        if (ModbusUtil.isBlank(port)) {
+            throw new IllegalArgumentException("Port must not be null or empty");
+        }
+        return this + port;
+    }
 }


### PR DESCRIPTION
Hi,

Current use of getSlave(int) method is incorrect because we ask for the key that we did not put at the first place.
Also when closing serial slave we did not remove by portname of serial params. I fixed those problems and added some necessary synchronization.
