### PR TITLE
Bump jSerialComm for fixed POSIX signal handling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <dependency>
             <groupId>com.fazecast</groupId>
             <artifactId>jSerialComm</artifactId>
-            <version>2.8.5</version>
+            <version>2.9.3</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
jSerialComm 2.8.5 overeagerly blocks SIGINT and SIGTERM which prevents normally terminating the Java application/VM. For example, stopping with systemd takes way longer than necessary (when the process gets SIGKILL-ed after a timeout) and shutdown hooks will not be run.

SIGTERM and SIGINT are no longer blocked with jSerialComm 2.9.1 and this commit bumps the dependency to the most recent release 2.9.3.