### PR TITLE
fix: ensure unique transaction IDs for concurrent requests

### DIFF
--- a/src/main/java/com/ghgande/j2mod/modbus/io/ModbusTCPTransaction.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/io/ModbusTCPTransaction.java
@@ -238,14 +238,8 @@ public class ModbusTCPTransaction extends ModbusTransaction {
      */
     private synchronized void incrementTransactionID() {
         if (isCheckingValidity()) {
-            if (transactionID >= Modbus.MAX_TRANSACTION_ID) {
-                transactionID = Modbus.DEFAULT_TRANSACTION_ID;
-            }
-            else {
-                transactionID++;
-            }
+            request.setTransactionID(nextTransactionID());
         }
-        request.setTransactionID(getTransactionID());
     }
 
 }

--- a/src/main/java/com/ghgande/j2mod/modbus/io/ModbusTransaction.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/io/ModbusTransaction.java
@@ -22,6 +22,7 @@ import com.ghgande.j2mod.modbus.msg.ModbusRequest;
 import com.ghgande.j2mod.modbus.msg.ModbusResponse;
 
 import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Interface defining a ModbusTransaction.
@@ -42,7 +43,7 @@ public abstract class ModbusTransaction {
     boolean validityCheck = Modbus.DEFAULT_VALIDITYCHECK;
     int retries = Modbus.DEFAULT_RETRIES;
     private final Random random = new Random(System.nanoTime());
-    static int transactionID = Modbus.DEFAULT_TRANSACTION_ID;
+    static final AtomicInteger transactionID = new AtomicInteger(Modbus.DEFAULT_TRANSACTION_ID);
 
     /**
      * Returns the <tt>ModbusRequest</tt> instance
@@ -67,7 +68,7 @@ public abstract class ModbusTransaction {
     public void setRequest(ModbusRequest req) {
         request = req;
         if (req != null) {
-            request.setTransactionID(getTransactionID());
+            request.setTransactionID(nextTransactionID());
         }
     }
 
@@ -127,22 +128,30 @@ public abstract class ModbusTransaction {
     }
 
     /**
-     * getTransactionID -- get the next transaction ID to use.
-     * @return next transaction ID to use
+     * Retrieves the current transaction ID.
+     *
+     * @return The current transaction ID, guaranteed to be within the valid range.
      */
-    public synchronized int getTransactionID() {
-        /*
-         * Ensure that the transaction ID is in the valid range between
-         * 0 and MAX_TRANSACTION_ID (65534).  If not, the value will be forced
-         * to 0.
-         */
-        if (transactionID < Modbus.DEFAULT_TRANSACTION_ID && isCheckingValidity()) {
-            transactionID = Modbus.DEFAULT_TRANSACTION_ID;
-        }
-        if (transactionID >= Modbus.MAX_TRANSACTION_ID) {
-            transactionID = Modbus.DEFAULT_TRANSACTION_ID;
-        }
-        return transactionID;
+    public int getTransactionID() {
+        return transactionID.get();
+    }
+
+    /**
+     * Atomically increments the global transaction ID counter and returns the
+     * new value. The value wraps around to {@link Modbus#DEFAULT_TRANSACTION_ID}
+     * when it reaches {@link Modbus#MAX_TRANSACTION_ID}.
+     *
+     * <p>This method is safe to call from multiple threads concurrently.
+     *
+     * @return the next unique transaction ID
+     */
+    static int nextTransactionID() {
+        return transactionID.updateAndGet(current -> {
+            if (current < Modbus.DEFAULT_TRANSACTION_ID || current >= Modbus.MAX_TRANSACTION_ID) {
+                return Modbus.DEFAULT_TRANSACTION_ID;
+            }
+            return current + 1;
+        });
     }
 
     /**

--- a/src/main/java/com/ghgande/j2mod/modbus/io/ModbusUDPTransaction.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/io/ModbusUDPTransaction.java
@@ -172,18 +172,12 @@ public class ModbusUDPTransaction extends ModbusTransaction {
      * Toggles the transaction identifier, to ensure
      * that each transaction has a distinctive
      * identifier.<br>
-     * When the maximum value of 65535 has been reached,
-     * the identifiers will start from zero again.
+     * When the maximum value of {@link Modbus#MAX_TRANSACTION_ID} has been
+     * reached, the identifiers will start from zero again.
      */
     private void incrementTransactionID() {
         if (isCheckingValidity()) {
-            if (transactionID >= Modbus.MAX_TRANSACTION_ID) {
-                transactionID = Modbus.DEFAULT_TRANSACTION_ID;
-            }
-            else {
-                transactionID++;
-            }
+            request.setTransactionID(nextTransactionID());
         }
-        request.setTransactionID(getTransactionID());
     }
 }

--- a/src/test/java/com/ghgande/j2mod/modbus/io/ModbusTransactionIDTest.java
+++ b/src/test/java/com/ghgande/j2mod/modbus/io/ModbusTransactionIDTest.java
@@ -1,0 +1,222 @@
+/*
+ * Copyright 2002-2016 jamod & j2mod development teams
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ghgande.j2mod.modbus.io;
+
+import com.ghgande.j2mod.modbus.Modbus;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static com.ghgande.j2mod.modbus.Modbus.READ_MULTIPLE_REGISTERS;
+import static com.ghgande.j2mod.modbus.msg.ModbusRequest.createModbusRequest;
+import static org.junit.Assert.*;
+
+/**
+ * Tests that the shared transaction ID counter in {@link ModbusTransaction}
+ * produces unique IDs under concurrent access and wraps correctly.
+ */
+public class ModbusTransactionIDTest {
+
+    @Before
+    public void resetTransactionID() {
+        ModbusTransaction.transactionID.set(Modbus.DEFAULT_TRANSACTION_ID);
+    }
+
+    @Test
+    public void testGetTransactionIDReturnsCurrentValue() {
+        ModbusTransaction.transactionID.set(42);
+        ModbusTCPTransaction transaction = new ModbusTCPTransaction();
+        assertEquals(42, transaction.getTransactionID());
+    }
+
+    @Test
+    public void testSettingRequestWillResetTransactionIDWhenAtMax() {
+        ModbusTransaction.transactionID.set(Modbus.MAX_TRANSACTION_ID);
+        ModbusTCPTransaction transaction = new ModbusTCPTransaction();
+        transaction.setRequest(createModbusRequest(READ_MULTIPLE_REGISTERS));
+        assertEquals(Modbus.DEFAULT_TRANSACTION_ID, transaction.getTransactionID());
+    }
+
+    @Test
+    public void testSettingRequestWillResetTransactionIDWhenAboveMax() {
+        ModbusTransaction.transactionID.set(Modbus.MAX_TRANSACTION_ID + 1);
+        ModbusTCPTransaction transaction = new ModbusTCPTransaction();
+        transaction.setRequest(createModbusRequest(READ_MULTIPLE_REGISTERS));
+        assertEquals(Modbus.DEFAULT_TRANSACTION_ID, transaction.getTransactionID());
+    }
+
+    @Test
+    public void testSettingRequestWillResetTransactionIDWhenNegative() {
+        ModbusTransaction.transactionID.set(-1);
+        ModbusTCPTransaction transaction = new ModbusTCPTransaction();
+        transaction.setRequest(createModbusRequest(READ_MULTIPLE_REGISTERS));
+        assertEquals(Modbus.DEFAULT_TRANSACTION_ID, transaction.getTransactionID());
+    }
+
+    /**
+     * Verifies that concurrent threads calling getAndUpdate on the shared
+     * AtomicInteger counter never produce duplicate transaction IDs.
+     *
+     * Each thread atomically increments the counter and records the value
+     * it obtained. With correct atomicity, every value must be unique.
+     */
+    @Test
+    public void testConcurrentIncrementProducesUniqueIDs() throws InterruptedException {
+        int threadCount = 16;
+        int incrementsPerThread = 1000;
+        int totalIncrements = threadCount * incrementsPerThread;
+
+        Set<Integer> observedIDs = ConcurrentHashMap.newKeySet();
+        AtomicBoolean duplicateFound = new AtomicBoolean(false);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+
+        for (int t = 0; t < threadCount; t++) {
+            new Thread(() -> {
+                try {
+                    startLatch.await();
+                    for (int i = 0; i < incrementsPerThread; i++) {
+                        int id = new DemoTransaction().incrementTransactionID();
+                        if (!observedIDs.add(id)) {
+                            duplicateFound.set(true);
+                        }
+                    }
+                }
+                catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                finally {
+                    doneLatch.countDown();
+                }
+            }).start();
+        }
+
+        // Release all threads at once
+        startLatch.countDown();
+        doneLatch.await();
+
+        assertFalse("Duplicate transaction IDs were produced under concurrent access", duplicateFound.get());
+        assertEquals("Expected exactly " + totalIncrements + " unique IDs", totalIncrements, observedIDs.size());
+    }
+
+    /**
+     * Verifies that the counter wraps around correctly when it reaches
+     * MAX_TRANSACTION_ID under concurrent access.
+     */
+    @Test
+    public void testConcurrentIncrementWrapsCorrectly() throws InterruptedException {
+        // Set counter close to the wrap point
+        ModbusTransaction.transactionID.set(Modbus.MAX_TRANSACTION_ID - 10);
+
+        int threadCount = 8;
+        int incrementsPerThread = 100;
+
+        Set<Integer> observedIDs = ConcurrentHashMap.newKeySet();
+        AtomicBoolean duplicateFound = new AtomicBoolean(false);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+
+        for (int t = 0; t < threadCount; t++) {
+            new Thread(() -> {
+                try {
+                    startLatch.await();
+                    for (int i = 0; i < incrementsPerThread; i++) {
+                        int id = new DemoTransaction().incrementTransactionID();
+                        if (!observedIDs.add(id)) {
+                            duplicateFound.set(true);
+                        }
+                    }
+                }
+                catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                finally {
+                    doneLatch.countDown();
+                }
+            }).start();
+        }
+
+        startLatch.countDown();
+        doneLatch.await();
+
+        assertFalse("Duplicate transaction IDs were produced during wrap-around", duplicateFound.get());
+
+        // All observed IDs must be in valid range
+        for (int id : observedIDs) {
+            assertTrue("Transaction ID out of range: " + id,
+                    id >= Modbus.DEFAULT_TRANSACTION_ID && id <= Modbus.MAX_TRANSACTION_ID);
+        }
+    }
+
+    @Test
+    public void testConcurrentSetRequestAcrossTransactionsAssignsUniqueTransactionIDs() throws InterruptedException {
+        int threadCount = 2;
+
+        Set<Integer> observedIDs = ConcurrentHashMap.newKeySet();
+        AtomicBoolean duplicateFound = new AtomicBoolean(false);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch doneLatch = new CountDownLatch(threadCount);
+
+        for (int t = 0; t < threadCount; t++) {
+            new Thread(() -> {
+                try {
+                    startLatch.await();
+
+                    ModbusTCPTransaction transaction = new ModbusTCPTransaction();
+                    transaction.setRequest(createModbusRequest(READ_MULTIPLE_REGISTERS));
+
+                    int assignedID = transaction.getRequest().getTransactionID();
+                    if (!observedIDs.add(assignedID)) {
+                        duplicateFound.set(true);
+                    }
+                }
+                catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+                finally {
+                    doneLatch.countDown();
+                }
+            }).start();
+        }
+
+        startLatch.countDown();
+        doneLatch.await();
+
+        assertFalse("Duplicate transaction IDs were assigned by setRequest under concurrent access", duplicateFound.get());
+        assertEquals("Expected one unique transaction ID per transaction", threadCount, observedIDs.size());
+    }
+
+    private static class DemoTransaction extends ModbusTransaction {
+
+        @Override
+        public void execute() {
+            throw new UnsupportedOperationException("Not supported yet.");
+        }
+
+        public int incrementTransactionID() {
+            return isCheckingValidity() ? transactionID.updateAndGet(current -> {
+                if (current >= Modbus.MAX_TRANSACTION_ID) {
+                    return Modbus.DEFAULT_TRANSACTION_ID;
+                }
+                return current + 1;
+            }) : getTransactionID();
+        }
+    }
+}


### PR DESCRIPTION
Prevent reuse of transaction IDs across multiple outstanding Modbus requests.

Previously, identical transaction IDs could be reused while earlier requests were still in-flight, causing responses to be incorrectly matched. This resulted in inconsistent and mismatched data being returned to clients.

The fix guarantees that each request gets a unique transaction ID until its response is received, ensuring proper correlation between requests and responses.

Fixes #165