### PR TITLE
Update ModbusSerialTransport transmission delay handling

### DIFF
--- a/src/main/java/com/ghgande/j2mod/modbus/io/ModbusSerialTransport.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/io/ModbusSerialTransport.java
@@ -15,7 +15,6 @@
  */
 package com.ghgande.j2mod.modbus.io;
 
-import com.fazecast.jSerialComm.SerialPort;
 import com.ghgande.j2mod.modbus.Modbus;
 import com.ghgande.j2mod.modbus.ModbusIOException;
 import com.ghgande.j2mod.modbus.msg.ModbusMessage;
@@ -109,6 +108,15 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
         writeMessage(msg);
     }
 
+    /**
+     * Waits for transmissionTimeNanos time period to elapse beginning from the startTime.
+     * This wait measurement is approximate, based on the OS clock and will depend on whether
+     * the OS uses a real-time clock (RTC). For sub-millisecond periods this method uses a
+     * tight loop to check against the OS clock which in of itself can be an expensive CPU call.
+     *
+     * @param startTime Time to start the period from
+     * @param transmissionTimeNanos Number of milliseconds to wait
+     */
     private void waitForTransmission(long startTime, double transmissionTimeNanos) {
         if (transmissionTimeNanos >= NS_IN_A_MS) {
             try {

--- a/src/main/java/com/ghgande/j2mod/modbus/io/ModbusSerialTransport.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/io/ModbusSerialTransport.java
@@ -89,7 +89,8 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
         // If this isn't a Slave ID missmatch message
         if (msg.getAuxiliaryType().equals(ModbusResponse.AuxiliaryMessageTypes.UNIT_ID_MISSMATCH)) {
             logger.debug("Ignoring response not meant for us");
-        } else {
+        }
+        else {
             // We need to pause before sending the response
             waitBetweenFrames();
 
@@ -133,11 +134,13 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
                 final long totalSleepMillis = (long) ((sleepMillis * MILLIS_SLEEP_FUDGE_FACTOR) + nanosOverflow);
 
                 Thread.sleep(totalSleepMillis, totalSleepNanos);
-            }  catch (InterruptedException e) {
+            }
+            catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 logger.debug("nothing to do. Sleep interrupted.", e);
             }
-        } else if  (sleepNanos > 0) {
+        }
+        else if  (sleepNanos > 0) {
             // For delays less than a millisecond, we need to chew CPU cycles unfortunately
             // There are some fiddle factors here to allow for some oddities in the hardware
             final int priority = Thread.currentThread().getPriority();
@@ -147,7 +150,8 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
                 while (System.nanoTime() < end) {
                     // noop
                 }
-            } finally {
+            }
+            finally {
                 Thread.currentThread().setPriority(priority);
             }
         }
@@ -169,7 +173,8 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
             // Wait here for the message to have been sent
             final double transmissionTimeNanos = 1_000_000_000.0 * msg.getOutputLength() / getCharactersPerSecond();
             waitForTransmission(startTime, transmissionTimeNanos);
-        } finally {
+        }
+        finally {
             notifyListenersAfterWrite(msg);
         }
     }
@@ -201,7 +206,8 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
             setTimeout(timeout);
             try {
                 commPort.open();
-            } catch (IOException e) {
+            }
+            catch (IOException e) {
                 throw new ModbusIOException(String.format("Cannot open port %s - %s", commPort.getDescriptivePortName(), e.getMessage()));
             }
         }
@@ -433,10 +439,12 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
             int cnt = commPort.readBytes(buffer, 1);
             if (cnt != 1) {
                 throw new IOException(CANNOT_READ_FROM_SERIAL_PORT);
-            } else {
+            }
+            else {
                 return buffer[0] & 0xff;
             }
-        } else {
+        }
+        else {
             throw new IOException(COMM_PORT_IS_NOT_VALID_OR_NOT_OPEN);
         }
     }
@@ -454,7 +462,8 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
             if (cnt != bytesToRead) {
                 throw new IOException("Cannot read from serial port - truncated");
             }
-        } else {
+        }
+        else {
             throw new IOException(COMM_PORT_IS_NOT_VALID_OR_NOT_OPEN);
         }
     }
@@ -470,7 +479,8 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
     final int writeBytes(byte[] buffer, int bytesToWrite) throws IOException {
         if (commPort != null && commPort.isOpen()) {
             return commPort.writeBytes(buffer, bytesToWrite);
-        } else {
+        }
+        else {
             throw new IOException(COMM_PORT_IS_NOT_VALID_OR_NOT_OPEN);
         }
     }
@@ -488,11 +498,14 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
             int cnt = commPort.readBytes(buffer, 1);
             if (cnt != 1) {
                 throw new IOException(CANNOT_READ_FROM_SERIAL_PORT);
-            } else if (buffer[0] == ':') {
+            }
+            else if (buffer[0] == ':') {
                 return FRAME_START;
-            } else if (buffer[0] == '\r' || buffer[0] == '\n') {
+            }
+            else if (buffer[0] == '\r' || buffer[0] == '\n') {
                 return FRAME_END;
-            } else {
+            }
+            else {
                 if (logger.isDebugEnabled()) {
                     logger.debug("Read From buffer: {} ({})", buffer[0], String.format("%02X", buffer[0]));
                 }
@@ -500,7 +513,8 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
                 cnt = commPort.readBytes(buffer, 1);
                 if (cnt != 1) {
                     throw new IOException(CANNOT_READ_FROM_SERIAL_PORT);
-                } else {
+                }
+                else {
                     int combinedValue = (Character.digit(firstValue, 16) << 4) + Character.digit(buffer[0], 16);
                     if (logger.isDebugEnabled()) {
                         logger.debug("Returning combined value of: {}", String.format("%02X", combinedValue));
@@ -508,7 +522,8 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
                     return combinedValue;
                 }
             }
-        } else {
+        }
+        else {
             throw new IOException(COMM_PORT_IS_NOT_VALID_OR_NOT_OPEN);
         }
     }
@@ -529,10 +544,12 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
             if (value == FRAME_START) {
                 buffer = new byte[]{58};
                 logger.debug("Wrote FRAME_START");
-            } else if (value == FRAME_END) {
+            }
+            else if (value == FRAME_END) {
                 buffer = new byte[]{13, 10};
                 logger.debug("Wrote FRAME_END");
-            } else {
+            }
+            else {
                 buffer = ModbusUtil.toHex(value);
                 if (logger.isDebugEnabled()) {
                     logger.debug("Wrote byte {}={}", value, ModbusUtil.toHex(value));
@@ -540,10 +557,12 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
             }
             if (buffer != null) {
                 return commPort.writeBytes(buffer, buffer.length);
-            } else {
+            }
+            else {
                 throw new IOException("Message to send is empty");
             }
-        } else {
+        }
+        else {
             throw new IOException(COMM_PORT_IS_NOT_VALID_OR_NOT_OPEN);
         }
     }
@@ -566,7 +585,8 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
                 cnt++;
             }
             return cnt;
-        } else {
+        }
+        else {
             throw new IOException(COMM_PORT_IS_NOT_VALID_OR_NOT_OPEN);
         }
     }
@@ -616,7 +636,8 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
         // If a fixed delay has been set
         if (transDelayMS > 0) {
             ModbusUtil.sleep(transDelayMS);
-        } else {
+        }
+        else {
             // Make use we have a gap of 3.5 characters between adjacent requests
             // We have to do the calculations here because it is possible that the caller may have changed
             // the connection characteristics if they provided the connection instance
@@ -644,7 +665,8 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
     int getInterFrameDelay() {
         if (commPort.getBaudRate() > 19200) {
             return 1750;
-        } else {
+        }
+        else {
             long delay = Math.max(getCharIntervalMicro(Modbus.INTER_MESSAGE_GAP), Modbus.MINIMUM_TRANSMIT_DELAY * 1000L);
             return delay > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) delay;
         }
@@ -658,7 +680,8 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
     long getMaxCharDelay() {
         if (commPort.getBaudRate() > 19200) {
             return 1750;
-        } else {
+        }
+        else {
             return getCharIntervalMicro(Modbus.INTER_CHARACTER_GAP);
         }
     }

--- a/src/main/java/com/ghgande/j2mod/modbus/io/ModbusSerialTransport.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/io/ModbusSerialTransport.java
@@ -64,9 +64,8 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
     /**
      * Historical calibration factors, for Transmission wait timing.
      */
-    private static final double MILLIS_SLEEP_FUDGE_FACTOR = 1.7;
-    private static final double NANOS_SLEEP_FUDGE_FACTOR_SHORT = 1.3;
-    private static final double NANOS_SLEEP_FUDGE_FACTOR_LONG = 1.5;
+    private static final double LONG_DELAY_FUDGE_FACTOR = 1.7;
+    private static final double SHORT_DELAY_FUDGE_FACTOR = 1.3;
 
     private AbstractSerialConnection commPort;
     boolean echo = false;     // require RS-485 echo processing
@@ -121,32 +120,27 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
     }
 
     private void waitForTransmission(long startTime, double transmissionTimeNanos) {
-        final long sleepMillis = (long) Math.floor(transmissionTimeNanos / NS_IN_A_MS);
-        final double sleepNanos = transmissionTimeNanos % NS_IN_A_MS;
-
-        if (sleepMillis > 0) {
+        if (transmissionTimeNanos >= NS_IN_A_MS) {
             try {
-                final double fudgedNanoSleep = sleepNanos * NANOS_SLEEP_FUDGE_FACTOR_LONG;
+                final long adjustedDelay = (long) (transmissionTimeNanos * LONG_DELAY_FUDGE_FACTOR);
+                final long sleepMillis = adjustedDelay / NS_IN_A_MS;
+                final int sleepNanos = (int) (adjustedDelay % NS_IN_A_MS);
 
-                final int totalSleepNanos = (int) fudgedNanoSleep % NS_IN_A_MS;
-                final int nanosOverflow = (int) fudgedNanoSleep / NS_IN_A_MS;
-
-                final long totalSleepMillis = (long) ((sleepMillis * MILLIS_SLEEP_FUDGE_FACTOR) + nanosOverflow);
-
-                Thread.sleep(totalSleepMillis, totalSleepNanos);
+                Thread.sleep(sleepMillis, sleepNanos);
             }
             catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 logger.debug("nothing to do. Sleep interrupted.", e);
             }
         }
-        else if  (sleepNanos > 0) {
+        else if  (transmissionTimeNanos > 0) {
             // For delays less than a millisecond, we need to chew CPU cycles unfortunately
             // There are some fiddle factors here to allow for some oddities in the hardware
             final int priority = Thread.currentThread().getPriority();
             try {
                 Thread.currentThread().setPriority(Thread.MIN_PRIORITY);
-                final long end = startTime + (long) (sleepNanos * NANOS_SLEEP_FUDGE_FACTOR_SHORT);
+                final long adjustedDelay = (long) (transmissionTimeNanos * SHORT_DELAY_FUDGE_FACTOR);
+                final long end = startTime + adjustedDelay;
                 while (System.nanoTime() < end) {
                     // noop
                 }

--- a/src/main/java/com/ghgande/j2mod/modbus/io/ModbusSerialTransport.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/io/ModbusSerialTransport.java
@@ -57,9 +57,17 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
     /**
      * The number of nanoseconds there is in a millisecond
      */
-    private static final int NS_IN_A_MS = 1000000;
+    private static final int NS_IN_A_MS = 1_000_000;
     private static final String CANNOT_READ_FROM_SERIAL_PORT = "Cannot read from serial port";
     private static final String COMM_PORT_IS_NOT_VALID_OR_NOT_OPEN = "Comm port is not valid or not open";
+
+    /**
+     * Historical calibration factors, for Transmission wait timing.
+     */
+    private static final double MILLIS_SLEEP_FUDGE_FACTOR = 1.7;
+    private static final double NANOS_SLEEP_FUDGE_FACTOR_SHORT = 1.3;
+    private static final double NANOS_SLEEP_FUDGE_FACTOR_LONG = 1.5;
+
     private AbstractSerialConnection commPort;
     boolean echo = false;     // require RS-485 echo processing
     private final Set<AbstractSerialTransportListener> listeners = Collections.synchronizedSet(new HashSet<AbstractSerialTransportListener>());
@@ -81,8 +89,7 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
         // If this isn't a Slave ID missmatch message
         if (msg.getAuxiliaryType().equals(ModbusResponse.AuxiliaryMessageTypes.UNIT_ID_MISSMATCH)) {
             logger.debug("Ignoring response not meant for us");
-        }
-        else {
+        } else {
             // We need to pause before sending the response
             waitBetweenFrames();
 
@@ -97,6 +104,56 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
     }
 
     /**
+     * Calculates the estimated serial character throughput based on the current port configuration.
+     *
+     * @return Characters per second. Never less than 10, which serves as a
+     * defensive fallback for invalid or unexpected port settings.
+     */
+    private double getCharactersPerSecond() {
+        final double baudRate = commPort.getBaudRate();
+        final double startBit = 1.0;
+        final double dataBits = commPort.getNumDataBits() == 0 ? 8 : commPort.getNumDataBits();
+        final double stopBits = commPort.getNumStopBits() == 0 ? 1 : commPort.getNumStopBits();
+        final double parityBits = commPort.getParity() == SerialPort.NO_PARITY ? 0 : 1;
+
+        return Math.max(10.0, baudRate / (startBit + dataBits + stopBits + parityBits));
+    }
+
+    private void waitForTransmission(long startTime, double transmissionTimeNanos) {
+        final long sleepMillis = (long) Math.floor(transmissionTimeNanos / NS_IN_A_MS);
+        final double sleepNanos = transmissionTimeNanos % NS_IN_A_MS;
+
+        if (sleepMillis > 0) {
+            try {
+                final double fudgedNanoSleep = sleepNanos * NANOS_SLEEP_FUDGE_FACTOR_LONG;
+
+                final int totalSleepNanos = (int) fudgedNanoSleep % NS_IN_A_MS;
+                final int nanosOverflow = (int) fudgedNanoSleep / NS_IN_A_MS;
+
+                final long totalSleepMillis = (long) ((sleepMillis * MILLIS_SLEEP_FUDGE_FACTOR) + nanosOverflow);
+
+                Thread.sleep(totalSleepMillis, totalSleepNanos);
+            }  catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                logger.debug("nothing to do. Sleep interrupted.", e);
+            }
+        } else if  (sleepNanos > 0) {
+            // For delays less than a millisecond, we need to chew CPU cycles unfortunately
+            // There are some fiddle factors here to allow for some oddities in the hardware
+            final int priority = Thread.currentThread().getPriority();
+            try {
+                Thread.currentThread().setPriority(Thread.MIN_PRIORITY);
+                final long end = startTime + (long) (sleepNanos * NANOS_SLEEP_FUDGE_FACTOR_SHORT);
+                while (System.nanoTime() < end) {
+                    // noop
+                }
+            } finally {
+                Thread.currentThread().setPriority(priority);
+            }
+        }
+    }
+
+    /**
      * Writes the request/response message to the port
      *
      * @param msg Message to write
@@ -107,37 +164,12 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
         notifyListenersBeforeWrite(msg);
         try {
             writeMessageOut(msg);
-            long startTime = System.nanoTime();
+            final long startTime = System.nanoTime();
 
             // Wait here for the message to have been sent
-
-            double bytesPerSec = ((double)commPort.getBaudRate()) / (((commPort.getNumDataBits() == 0) ? 8 : commPort.getNumDataBits()) + ((commPort.getNumStopBits() == 0) ? 1 : commPort.getNumStopBits()) + ((commPort.getParity() == SerialPort.NO_PARITY) ? 0 : 1));
-            double delay = 1000000000.0 * msg.getOutputLength() / bytesPerSec;
-            double delayMilliSeconds = Math.floor(delay / 1000000);
-            double delayNanoSeconds = delay % 1000000;
-            try {
-
-                // For delays less than a millisecond, we need to chew CPU cycles unfortunately
-                // There are some fiddle factors here to allow for some oddities in the hardware
-
-                if (delayMilliSeconds == 0.0) {
-                    int priority = Thread.currentThread().getPriority();
-                    Thread.currentThread().setPriority(Thread.MIN_PRIORITY);
-                    long end = startTime + ((int) (delayNanoSeconds * 1.3));
-                    while (System.nanoTime() < end) {
-                        // noop
-                    }
-                    Thread.currentThread().setPriority(priority);
-                }
-                else {
-                    Thread.sleep((int) (delayMilliSeconds * 1.7), (int) (delayNanoSeconds * 1.5));
-                }
-            }
-            catch (Exception e) {
-                logger.debug("nothing to do");
-            }
-        }
-        finally {
+            final double transmissionTimeNanos = 1_000_000_000.0 * msg.getOutputLength() / getCharactersPerSecond();
+            waitForTransmission(startTime, transmissionTimeNanos);
+        } finally {
             notifyListenersAfterWrite(msg);
         }
     }
@@ -169,8 +201,7 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
             setTimeout(timeout);
             try {
                 commPort.open();
-            }
-            catch (IOException e) {
+            } catch (IOException e) {
                 throw new ModbusIOException(String.format("Cannot open port %s - %s", commPort.getDescriptivePortName(), e.getMessage()));
             }
         }
@@ -200,7 +231,6 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
      *
      * @param listener Listener that received this request
      * @return a <code>ModbusRequest</code> value
-     *
      * @throws ModbusIOException if an error occurs
      */
     protected abstract ModbusRequest readRequestIn(AbstractModbusListener listener) throws ModbusIOException;
@@ -210,7 +240,6 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
      * responding to a master writeRequest request.
      *
      * @return a <code>ModbusResponse</code> value
-     *
      * @throws ModbusIOException if an error occurs
      */
     protected abstract ModbusResponse readResponseIn() throws ModbusIOException;
@@ -328,7 +357,7 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
             }
         }
     }
-    
+
     /**
      * <code>setCommPort</code> sets the comm port member and prepares the input
      * and output streams to be used for reading from and writing to.
@@ -396,7 +425,6 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
      * Reads a byte from the comms port
      *
      * @return Value of the byte
-     *
      * @throws IOException If it cannot read or times out
      */
     protected int readByte() throws IOException {
@@ -405,12 +433,10 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
             int cnt = commPort.readBytes(buffer, 1);
             if (cnt != 1) {
                 throw new IOException(CANNOT_READ_FROM_SERIAL_PORT);
-            }
-            else {
+            } else {
                 return buffer[0] & 0xff;
             }
-        }
-        else {
+        } else {
             throw new IOException(COMM_PORT_IS_NOT_VALID_OR_NOT_OPEN);
         }
     }
@@ -428,8 +454,7 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
             if (cnt != bytesToRead) {
                 throw new IOException("Cannot read from serial port - truncated");
             }
-        }
-        else {
+        } else {
             throw new IOException(COMM_PORT_IS_NOT_VALID_OR_NOT_OPEN);
         }
     }
@@ -440,14 +465,12 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
      * @param buffer       Buffer to write
      * @param bytesToWrite Number of bytes to write
      * @return Number of bytes written
-     *
      * @throws java.io.IOException if writing to invalid port
      */
     final int writeBytes(byte[] buffer, int bytesToWrite) throws IOException {
         if (commPort != null && commPort.isOpen()) {
             return commPort.writeBytes(buffer, bytesToWrite);
-        }
-        else {
+        } else {
             throw new IOException(COMM_PORT_IS_NOT_VALID_OR_NOT_OPEN);
         }
     }
@@ -457,7 +480,6 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
      * It handles the special start and end frame markers
      *
      * @return Byte value of the next ASCII couplet
-     *
      * @throws IOException If a problem with the port
      */
     int readAsciiByte() throws IOException {
@@ -466,14 +488,11 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
             int cnt = commPort.readBytes(buffer, 1);
             if (cnt != 1) {
                 throw new IOException(CANNOT_READ_FROM_SERIAL_PORT);
-            }
-            else if (buffer[0] == ':') {
+            } else if (buffer[0] == ':') {
                 return FRAME_START;
-            }
-            else if (buffer[0] == '\r' || buffer[0] == '\n') {
+            } else if (buffer[0] == '\r' || buffer[0] == '\n') {
                 return FRAME_END;
-            }
-            else {
+            } else {
                 if (logger.isDebugEnabled()) {
                     logger.debug("Read From buffer: {} ({})", buffer[0], String.format("%02X", buffer[0]));
                 }
@@ -481,8 +500,7 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
                 cnt = commPort.readBytes(buffer, 1);
                 if (cnt != 1) {
                     throw new IOException(CANNOT_READ_FROM_SERIAL_PORT);
-                }
-                else {
+                } else {
                     int combinedValue = (Character.digit(firstValue, 16) << 4) + Character.digit(buffer[0], 16);
                     if (logger.isDebugEnabled()) {
                         logger.debug("Returning combined value of: {}", String.format("%02X", combinedValue));
@@ -490,8 +508,7 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
                     return combinedValue;
                 }
             }
-        }
-        else {
+        } else {
             throw new IOException(COMM_PORT_IS_NOT_VALID_OR_NOT_OPEN);
         }
     }
@@ -503,7 +520,6 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
      *
      * @param value Value to write
      * @return Number of bytes written
-     *
      * @throws IOException If a problem with the port
      */
     final int writeAsciiByte(int value) throws IOException {
@@ -513,12 +529,10 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
             if (value == FRAME_START) {
                 buffer = new byte[]{58};
                 logger.debug("Wrote FRAME_START");
-            }
-            else if (value == FRAME_END) {
+            } else if (value == FRAME_END) {
                 buffer = new byte[]{13, 10};
                 logger.debug("Wrote FRAME_END");
-            }
-            else {
+            } else {
                 buffer = ModbusUtil.toHex(value);
                 if (logger.isDebugEnabled()) {
                     logger.debug("Wrote byte {}={}", value, ModbusUtil.toHex(value));
@@ -526,12 +540,10 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
             }
             if (buffer != null) {
                 return commPort.writeBytes(buffer, buffer.length);
-            }
-            else {
+            } else {
                 throw new IOException("Message to send is empty");
             }
-        }
-        else {
+        } else {
             throw new IOException(COMM_PORT_IS_NOT_VALID_OR_NOT_OPEN);
         }
     }
@@ -542,7 +554,6 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
      * @param buffer       Buffer of bytes to write
      * @param bytesToWrite Number of characters to write
      * @return Number of bytes written
-     *
      * @throws IOException If a problem with the port
      */
     int writeAsciiBytes(byte[] buffer, long bytesToWrite) throws IOException {
@@ -555,8 +566,7 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
                 cnt++;
             }
             return cnt;
-        }
-        else {
+        } else {
             throw new IOException(COMM_PORT_IS_NOT_VALID_OR_NOT_OPEN);
         }
     }
@@ -606,8 +616,7 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
         // If a fixed delay has been set
         if (transDelayMS > 0) {
             ModbusUtil.sleep(transDelayMS);
-        }
-        else {
+        } else {
             // Make use we have a gap of 3.5 characters between adjacent requests
             // We have to do the calculations here because it is possible that the caller may have changed
             // the connection characteristics if they provided the connection instance
@@ -635,8 +644,7 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
     int getInterFrameDelay() {
         if (commPort.getBaudRate() > 19200) {
             return 1750;
-        }
-        else {
+        } else {
             long delay = Math.max(getCharIntervalMicro(Modbus.INTER_MESSAGE_GAP), Modbus.MINIMUM_TRANSMIT_DELAY * 1000L);
             return delay > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) delay;
         }
@@ -650,8 +658,7 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
     long getMaxCharDelay() {
         if (commPort.getBaudRate() > 19200) {
             return 1750;
-        }
-        else {
+        } else {
             return getCharIntervalMicro(Modbus.INTER_CHARACTER_GAP);
         }
     }

--- a/src/main/java/com/ghgande/j2mod/modbus/io/ModbusSerialTransport.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/io/ModbusSerialTransport.java
@@ -58,6 +58,12 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
      * The number of nanoseconds there is in a millisecond
      */
     private static final int NS_IN_A_MS = 1_000_000;
+
+    /**
+     * The number of nanoseconds there is in a second
+     */
+    private static final int NS_IN_A_SEC = 1_000_000_000;
+
     private static final String CANNOT_READ_FROM_SERIAL_PORT = "Cannot read from serial port";
     private static final String COMM_PORT_IS_NOT_VALID_OR_NOT_OPEN = "Comm port is not valid or not open";
 
@@ -101,22 +107,6 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
     @Override
     public void writeRequest(ModbusRequest msg) throws ModbusIOException {
         writeMessage(msg);
-    }
-
-    /**
-     * Calculates the estimated serial character throughput based on the current port configuration.
-     *
-     * @return Characters per second. Never less than 10, which serves as a
-     * defensive fallback for invalid or unexpected port settings.
-     */
-    private double getCharactersPerSecond() {
-        final double baudRate = commPort.getBaudRate();
-        final double startBit = 1.0;
-        final double dataBits = commPort.getNumDataBits() == 0 ? 8 : commPort.getNumDataBits();
-        final double stopBits = commPort.getNumStopBits() == 0 ? 1 : commPort.getNumStopBits();
-        final double parityBits = commPort.getParity() == SerialPort.NO_PARITY ? 0 : 1;
-
-        return Math.max(10.0, baudRate / (startBit + dataBits + stopBits + parityBits));
     }
 
     private void waitForTransmission(long startTime, double transmissionTimeNanos) {
@@ -165,7 +155,8 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
             final long startTime = System.nanoTime();
 
             // Wait here for the message to have been sent
-            final double transmissionTimeNanos = 1_000_000_000.0 * msg.getOutputLength() / getCharactersPerSecond();
+            final double charactersPerSecond = commPort.getBaudRate() / commPort.getBitsPerCharacter();
+            final double transmissionTimeNanos = NS_IN_A_SEC * msg.getOutputLength() / charactersPerSecond;
             waitForTransmission(startTime, transmissionTimeNanos);
         }
         finally {
@@ -454,7 +445,7 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
         if (commPort != null && commPort.isOpen()) {
             int cnt = commPort.readBytes(buffer, bytesToRead);
             if (cnt != bytesToRead) {
-                throw new IOException("Cannot read from serial port - truncated");
+                throw new IOException(String.format("Cannot read from serial port - truncated (expected %d bytes, got %d bytes)", bytesToRead, cnt));
             }
         }
         else {
@@ -691,7 +682,7 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
         // Make use we have a gap of 3.5 characters between adjacent requests
         // We have to do the calculations here because it is possible that the caller may have changed
         // the connection characteristics if they provided the connection instance
-        return (long) chars * NS_IN_A_MS * (1 + commPort.getNumDataBits() + commPort.getNumStopBits() + (commPort.getParity() == AbstractSerialConnection.NO_PARITY ? 0 : 1)) / commPort.getBaudRate();
+        return (long) (chars * NS_IN_A_MS * commPort.getBitsPerCharacter() / commPort.getBaudRate());
     }
 
     /**

--- a/src/main/java/com/ghgande/j2mod/modbus/net/AbstractSerialConnection.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/net/AbstractSerialConnection.java
@@ -50,10 +50,10 @@ public abstract class AbstractSerialConnection {
      * Timeout
      */
     public static final int TIMEOUT_NONBLOCKING = SerialPort.TIMEOUT_NONBLOCKING;
-   	public static final int TIMEOUT_READ_SEMI_BLOCKING = SerialPort.TIMEOUT_READ_SEMI_BLOCKING;
-   	public static final int TIMEOUT_READ_BLOCKING = SerialPort.TIMEOUT_READ_BLOCKING;
-   	public static final int TIMEOUT_WRITE_BLOCKING = SerialPort.TIMEOUT_WRITE_BLOCKING;
-   	public static final int TIMEOUT_SCANNER = SerialPort.TIMEOUT_SCANNER;
+    public static final int TIMEOUT_READ_SEMI_BLOCKING = SerialPort.TIMEOUT_READ_SEMI_BLOCKING;
+    public static final int TIMEOUT_READ_BLOCKING = SerialPort.TIMEOUT_READ_BLOCKING;
+    public static final int TIMEOUT_WRITE_BLOCKING = SerialPort.TIMEOUT_WRITE_BLOCKING;
+    public static final int TIMEOUT_SCANNER = SerialPort.TIMEOUT_SCANNER;
 
     /**
      * Opens the port and throws an error if it cannot for some reason
@@ -115,11 +115,33 @@ public abstract class AbstractSerialConnection {
     public abstract int getNumDataBits();
 
     /**
-     * Returns current stop bits
+     * Returns current stop bits configuration constant.
+     * <p>
+     * Use {@link #getStopBits()} to get the actual stop bits in bit times.
      *
-     * @return Number of stop bits
+     * @return Stop-bit configuration constant.
      */
     public abstract int getNumStopBits();
+
+    /**
+     * Returns current stop bits as actual bit times.
+     * <p>
+     * Use {@link #getNumStopBits()} to get the stop bits configuration constant.
+     *
+     * @return Stop-bit length in bit times.
+     */
+    public float getStopBits() {
+        switch (getNumStopBits()) {
+            case ONE_STOP_BIT:
+                return 1.0f;
+            case ONE_POINT_FIVE_STOP_BITS:
+                return 1.5f;
+            case TWO_STOP_BITS:
+                return 2.0f;
+            default:
+                return 1.0f;
+        }
+    }
 
     /**
      * Returns current parity
@@ -178,5 +200,21 @@ public abstract class AbstractSerialConnection {
      * @return Set of comm port names
      */
     public abstract Set<String> getCommPorts();
+
+    /**
+     * Returns the total number of serial bit-times required to transmit
+     * a single character with the current port configuration.
+     *
+     * @return Total bit-times per character.
+     */
+    public double getBitsPerCharacter() {
+        final double startBit = 1.0;
+        final int numDataBits = getNumDataBits();
+        final int dataBits = numDataBits == 0 ? 8 : numDataBits;
+        final double stopBits = getStopBits();
+        final double parityBits = getParity() == SerialPort.NO_PARITY ? 0 : 1;
+
+        return startBit + dataBits + stopBits + parityBits;
+    }
 
 }


### PR DESCRIPTION
Refactor transmission delay handling in `ModbusSerialTransport`

Changes:
- Fix `nanosecond timeout value out of range` exceptions.
- Fix serial throughput calculation by including the start bit.
- Extract sleep fudge factors into named constants.
- Normalize nanosecond overflow into milliseconds for `Thread.sleep()`.
- Improve readability and maintainability of transmission timing code.