### PR TITLE
Fix serial timing and validate baud rate calculations

### DIFF
--- a/src/main/java/com/ghgande/j2mod/modbus/Modbus.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/Modbus.java
@@ -319,7 +319,7 @@ public interface Modbus {
      * The number of characters delay that must be maintained between adjacent requests on
      * the same serial port (within the same transaction)
      */
-    double INTER_MESSAGE_GAP = 4;
+    double INTER_MESSAGE_GAP = 3.5;
 
     /**
      * The number of characters delay that is the allowed maximum between characters on

--- a/src/main/java/com/ghgande/j2mod/modbus/io/ModbusRTUTransport.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/io/ModbusRTUTransport.java
@@ -341,15 +341,16 @@ public class ModbusRTUTransport extends ModbusSerialTransport {
                     else {
                         // This message is not for us, read and wait for the 3.5t delay
 
+                        final long charTimeout = getMaxCharTimeout();
                         // Wait for max 1.5t for data to be available
                         while (true) {
                             boolean bytesAvailable = availableBytes() > 0;
                             if (!bytesAvailable) {
                                 // Sleep the 1.5t to see if there will be more data
                                 if (logger.isDebugEnabled()) {
-                                    logger.debug("Waiting for {} microsec", getMaxCharTimeout());
+                                    logger.debug("Waiting for {} microsec", charTimeout);
                                 }
-                                bytesAvailable = spinUntilBytesAvailable(getMaxCharTimeout());
+                                bytesAvailable = spinUntilBytesAvailable(charTimeout);
                             }
 
                             if (bytesAvailable) {
@@ -364,12 +365,13 @@ public class ModbusRTUTransport extends ModbusSerialTransport {
                             }
                         }
 
-                        // Wait for 2t to complete the 3.5t wait
+                        // Wait for the remaining time to complete the inter-frame interval
+                        final long remainingWait = getInterFrameDelay() - charTimeout;
                         // Is there is data available the interval was not respected, we should discard the message
                         if (logger.isDebugEnabled()) {
-                            logger.debug("Waiting for {} microsec", getCharIntervalMicro(2));
+                            logger.debug("Waiting for {} microsec", remainingWait);
                         }
-                        if (spinUntilBytesAvailable(getCharIntervalMicro(2))) {
+                        if (spinUntilBytesAvailable(remainingWait)) {
                             // Discard the message
                             if (logger.isDebugEnabled()) {
                                 logger.debug("Discarding message (More than 1.5t between characters!) - {}", ModbusUtil.toHex(byteInputOutputStream.getBuffer(), 0, byteInputOutputStream.size()));

--- a/src/main/java/com/ghgande/j2mod/modbus/io/ModbusRTUTransport.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/io/ModbusRTUTransport.java
@@ -347,9 +347,9 @@ public class ModbusRTUTransport extends ModbusSerialTransport {
                             if (!bytesAvailable) {
                                 // Sleep the 1.5t to see if there will be more data
                                 if (logger.isDebugEnabled()) {
-                                    logger.debug("Waiting for {} microsec", getMaxCharDelay());
+                                    logger.debug("Waiting for {} microsec", getMaxCharTimeout());
                                 }
-                                bytesAvailable = spinUntilBytesAvailable(getMaxCharDelay());
+                                bytesAvailable = spinUntilBytesAvailable(getMaxCharTimeout());
                             }
 
                             if (bytesAvailable) {

--- a/src/main/java/com/ghgande/j2mod/modbus/io/ModbusSerialTransport.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/io/ModbusSerialTransport.java
@@ -54,14 +54,19 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
     static final int FRAME_END = 2000;
 
     /**
-     * The number of nanoseconds there is in a millisecond
+     * The number of nanoseconds in a millisecond
      */
     private static final int NS_IN_A_MS = 1_000_000;
 
     /**
-     * The number of nanoseconds there is in a second
+     * The number of nanoseconds in a second
      */
     private static final int NS_IN_A_SEC = 1_000_000_000;
+
+    /**
+     * The number of microseconds in a second.
+     */
+    private static final double MICROS_IN_A_SEC = 1_000_000.0;
 
     private static final String CANNOT_READ_FROM_SERIAL_PORT = "Cannot read from serial port";
     private static final String COMM_PORT_IS_NOT_VALID_OR_NOT_OPEN = "Comm port is not valid or not open";
@@ -651,9 +656,14 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
     }
 
     /**
-     * In microseconds
+     * Calculates the inter-frame delay according to the
+     * MODBUS over Serial Line Specification V1.02.
+     * <ul>
+     *  <li> baud rates &le; 19200: 3.5 Character time </li>
+     *  <li> baud rates &gt; 19200: 1750 microseconds </li>
+     * </ul>
      *
-     * @return Delay between frames
+     * @return the inter-frame delay in microseconds
      */
     int getInterFrameDelay() {
         if (commPort.getBaudRate() > 19200) {
@@ -661,18 +671,23 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
         }
         else {
             long delay = Math.max(getCharIntervalMicro(Modbus.INTER_MESSAGE_GAP), Modbus.MINIMUM_TRANSMIT_DELAY * 1000L);
-            return delay > Integer.MAX_VALUE ? Integer.MAX_VALUE : (int) delay;
+            return (int) Math.min(Integer.MAX_VALUE, delay);
         }
     }
 
     /**
-     * The maximum delay between characters in microseconds
+     * Calculates the inter-character time-out according to the
+     * MODBUS over Serial Line Specification V1.02.
+     * <ul>
+     *  <li> baud rates &le; 19200: 1.5 Character time </li>
+     *  <li> baud rates &gt; 19200: 750 microseconds </li>
+     * </ul>
      *
-     * @return microseconds
+     * @return the inter-character time-out in microseconds
      */
-    long getMaxCharDelay() {
+    long getMaxCharTimeout() {
         if (commPort.getBaudRate() > 19200) {
-            return 1750;
+            return 750;
         }
         else {
             return getCharIntervalMicro(Modbus.INTER_CHARACTER_GAP);
@@ -690,7 +705,8 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
         // Make use we have a gap of 3.5 characters between adjacent requests
         // We have to do the calculations here because it is possible that the caller may have changed
         // the connection characteristics if they provided the connection instance
-        return (long) (chars * NS_IN_A_MS * commPort.getBitsPerCharacter() / commPort.getBaudRate());
+        final double microsPerChar = (commPort.getBitsPerCharacter() / (double) commPort.getBaudRate()) * MICROS_IN_A_SEC;
+        return (long) (microsPerChar * chars);
     }
 
     /**
@@ -698,7 +714,7 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
      * This method will repeatedly poll the available bytes, so it should not have any side effects.
      *
      * @param waitTimeMicroSec The time to wait for the condition to be true in microseconds
-     * @return true if the condition ended the spin, false if the tim
+     * @return true if the condition ended the spin, false if the timeout was reached
      */
     boolean spinUntilBytesAvailable(long waitTimeMicroSec) {
         long start = System.nanoTime();

--- a/src/main/java/com/ghgande/j2mod/modbus/io/ModbusSerialTransport.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/io/ModbusSerialTransport.java
@@ -636,10 +636,10 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
             ModbusUtil.sleep(transDelayMS);
         }
         else {
-            // Make use we have a gap of 3.5 characters between adjacent requests
+            // Make sure we have a gap of 3.5 characters between adjacent requests
             // We have to do the calculations here because it is possible that the caller may have changed
             // the connection characteristics if they provided the connection instance
-            int delay = getInterFrameDelay() / 1000;
+            int delay = (int) Math.ceil(getInterFrameDelay() / 1000.0);
 
             // How long since the last message we received
             long gapSinceLastMessage = (System.nanoTime() - lastTransactionTimestamp) / NS_IN_A_MS;

--- a/src/main/java/com/ghgande/j2mod/modbus/io/ModbusSerialTransport.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/io/ModbusSerialTransport.java
@@ -702,11 +702,8 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
      * @return microseconds
      */
     long getCharIntervalMicro(double chars) {
-        // Make sure we have a gap of 3.5 characters between adjacent requests
-        // We have to do the calculations here because it is possible that the caller may have changed
-        // the connection characteristics if they provided the connection instance
         final double microsPerChar = (commPort.getBitsPerCharacter() / (double) commPort.getBaudRate()) * MICROS_IN_A_SEC;
-        return (long) (microsPerChar * chars);
+        return (long) Math.ceil(microsPerChar * chars);
     }
 
     /**

--- a/src/main/java/com/ghgande/j2mod/modbus/io/ModbusSerialTransport.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/io/ModbusSerialTransport.java
@@ -702,7 +702,7 @@ public abstract class ModbusSerialTransport extends AbstractModbusTransport {
      * @return microseconds
      */
     long getCharIntervalMicro(double chars) {
-        // Make use we have a gap of 3.5 characters between adjacent requests
+        // Make sure we have a gap of 3.5 characters between adjacent requests
         // We have to do the calculations here because it is possible that the caller may have changed
         // the connection characteristics if they provided the connection instance
         final double microsPerChar = (commPort.getBitsPerCharacter() / (double) commPort.getBaudRate()) * MICROS_IN_A_SEC;

--- a/src/main/java/com/ghgande/j2mod/modbus/net/AbstractSerialConnection.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/net/AbstractSerialConnection.java
@@ -101,9 +101,11 @@ public abstract class AbstractSerialConnection {
     public abstract void close();
 
     /**
-     * Returns current baud rate
+     * Returns current baud rate.
+     * <p>
+     * For UART interfaces (RS-232 / RS-485), this is equal to the line bit rate in bits/s.
      *
-     * @return Baud rate
+     * @return Baud rate (bits/s)
      */
     public abstract int getBaudRate();
 
@@ -212,7 +214,7 @@ public abstract class AbstractSerialConnection {
         final int numDataBits = getNumDataBits();
         final int dataBits = numDataBits == 0 ? 8 : numDataBits;
         final double stopBits = getStopBits();
-        final double parityBits = getParity() == SerialPort.NO_PARITY ? 0 : 1;
+        final double parityBits = getParity() == NO_PARITY ? 0 : 1;
 
         return startBit + dataBits + stopBits + parityBits;
     }

--- a/src/main/java/com/ghgande/j2mod/modbus/util/SerialParameters.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/util/SerialParameters.java
@@ -945,9 +945,9 @@ public class SerialParameters {
                 ", echo=" + echo +
                 ", openDelay=" + openDelay +
                 ", rs485Mode=" + rs485Mode +
-                ", rs485TxEnableActiveHight=" + rs485TxEnableActiveHigh +
+                ", rs485TxEnableActiveHigh=" + rs485TxEnableActiveHigh +
                 ", rs485EnableTermination=" + rs485EnableTermination +
-                ", rs485RxDuringTx" + rs485RxDuringTx +
+                ", rs485RxDuringTx=" + rs485RxDuringTx +
                 ", rs485DelayBeforeTxMicroseconds=" + rs485DelayBeforeTxMicroseconds +
                 ", rs485DelayAfterTxMicroseconds=" + rs485DelayAfterTxMicroseconds +
                 '}';

--- a/src/main/java/com/ghgande/j2mod/modbus/util/SerialParameters.java
+++ b/src/main/java/com/ghgande/j2mod/modbus/util/SerialParameters.java
@@ -37,7 +37,7 @@ public class SerialParameters {
     private static final boolean DEFAULT_RS485_MODE = false;
     private static final boolean DEFAULT_RS485_TX_ENABLE_ACTIVE_HIGH = true;
     private static final boolean DEFAULT_RS485_ENABLE_TERMINATION = false;
-    private static final boolean DEFAULT_RS485_TX_DURING_RX = false;
+    private static final boolean DEFAULT_RS485_RX_DURING_TX = false;
     private static final int DEFAULT_RS485_DELAY_BEFORE_TX_MICROSECONDS = 1000;
     private static final int DEFAULT_RS485_DELAY_AFTER_TX_MICROSECONDS = 1000;
 
@@ -65,24 +65,13 @@ public class SerialParameters {
      * default values.
      */
     public SerialParameters() {
-        portName = "";
-        baudRate = 9600;
-        flowControlIn = AbstractSerialConnection.FLOW_CONTROL_DISABLED;
-        flowControlOut = AbstractSerialConnection.FLOW_CONTROL_DISABLED;
-        databits = 8;
-        stopbits = AbstractSerialConnection.ONE_STOP_BIT;
-        parity = AbstractSerialConnection.NO_PARITY;
-        // Historically, the encoding has been null which got converted to RTU
-        // by SerialConnection.open(). Let's make it more explicit which serial
-        // protocol will be used by default.
-        encoding = Modbus.SERIAL_ENCODING_RTU;
-        echo = false;
-        openDelay = AbstractSerialConnection.OPEN_DELAY;
-        rs485Mode = DEFAULT_RS485_MODE;
-        rs485TxEnableActiveHigh = DEFAULT_RS485_TX_ENABLE_ACTIVE_HIGH;
-        rs485DelayBeforeTxMicroseconds = DEFAULT_RS485_DELAY_BEFORE_TX_MICROSECONDS;
-        rs485DelayAfterTxMicroseconds = DEFAULT_RS485_DELAY_AFTER_TX_MICROSECONDS;
-        rs485DisableControl = DEFAULT_RS485_DISABLE_CONTROL;
+        this("", 9600,
+                AbstractSerialConnection.FLOW_CONTROL_DISABLED,
+                AbstractSerialConnection.FLOW_CONTROL_DISABLED,
+                8,
+                AbstractSerialConnection.ONE_STOP_BIT,
+                AbstractSerialConnection.NO_PARITY,
+                false);
     }
 
     /**
@@ -105,17 +94,17 @@ public class SerialParameters {
                             int stopbits,
                             int parity,
                             boolean echo) {
-        // Perform default initialization and update fields of interest
-        // afterwards.
-        this();
-        this.portName = portName;
-        this.baudRate = baudRate;
-        this.flowControlIn = flowControlIn;
-        this.flowControlOut = flowControlOut;
-        this.databits = databits;
-        this.stopbits = stopbits;
-        this.parity = parity;
-        this.echo = echo;
+        this(portName, baudRate,
+                flowControlIn,
+                flowControlOut,
+                databits,
+                stopbits,
+                parity,
+                echo,
+                DEFAULT_RS485_MODE,
+                DEFAULT_RS485_TX_ENABLE_ACTIVE_HIGH,
+                DEFAULT_RS485_DELAY_BEFORE_TX_MICROSECONDS,
+                DEFAULT_RS485_DELAY_AFTER_TX_MICROSECONDS);
     }
 
     /**
@@ -159,14 +148,27 @@ public class SerialParameters {
                             boolean rs485TxEnableActiveHigh,
                             int rs485DelayBeforeTxMicroseconds,
                             int rs485DelayAfterTxMicroseconds
-                            ) {
-        // Perform default non-RS-485 initialization and update fields of
-        // interest afterwards.
-        this(portName, baudRate, flowControlIn, flowControlOut, databits, stopbits, parity, echo);
+    ) {
+        this.portName = portName;
+        this.setBaudRate(baudRate);
+        this.flowControlIn = flowControlIn;
+        this.flowControlOut = flowControlOut;
+        this.databits = databits;
+        this.stopbits = stopbits;
+        this.parity = parity;
+        this.echo = echo;
         this.rs485Mode = rs485Mode;
         this.rs485TxEnableActiveHigh = rs485TxEnableActiveHigh;
         this.rs485DelayBeforeTxMicroseconds = rs485DelayBeforeTxMicroseconds;
         this.rs485DelayAfterTxMicroseconds = rs485DelayAfterTxMicroseconds;
+        // Historically, the encoding has been null which got converted to RTU
+        // by SerialConnection.open(). Let's make it more explicit which serial
+        // protocol will be used by default.
+        this.encoding = Modbus.SERIAL_ENCODING_RTU;
+        this.openDelay = AbstractSerialConnection.OPEN_DELAY;
+        this.rs485DisableControl = DEFAULT_RS485_DISABLE_CONTROL;
+        this.rs485EnableTermination = DEFAULT_RS485_ENABLE_TERMINATION;
+        this.rs485RxDuringTx = DEFAULT_RS485_RX_DURING_TX;
     }
 
     /**
@@ -217,21 +219,15 @@ public class SerialParameters {
     }
 
     /**
-     * Sets the baud rate.
+     * Sets the baud rate. Has to be &ge;1.
      *
      * @param rate the new baud rate.
      */
     public void setBaudRate(int rate) {
+        if (rate < 1) {
+            throw new IllegalArgumentException("Baud rate must be greater than 0, but was: " + rate);
+        }
         baudRate = rate;
-    }
-
-    /**
-     * Return the baud rate as <tt>int</tt>.
-     *
-     * @return the baud rate as <tt>int</tt>.
-     */
-    public int getBaudRate() {
-        return baudRate;
     }
 
     /**
@@ -240,7 +236,18 @@ public class SerialParameters {
      * @param rate the new baud rate.
      */
     public void setBaudRate(String rate) {
-        baudRate = Integer.parseInt(rate);
+        setBaudRate(Integer.parseInt(rate));
+    }
+
+    /**
+     * Return the baud rate as <tt>int</tt>.
+     * <p>
+     * Is guaranteed to return a value &ge;1
+     *
+     * @return the baud rate as <tt>int</tt>.
+     */
+    public int getBaudRate() {
+        return baudRate;
     }
 
     /**
@@ -407,7 +414,7 @@ public class SerialParameters {
     /**
      * Sets the number of stop bits. com.fazecast.jSerialComm.SerialPort stop-bit constants should be used in this method (ONE_STOP_BIT, ONE_POINT_FIVE_STOP_BITS, TWO_STOP_BITS)
      *
-     * @param stopbits the new number of stop bits setting. 
+     * @param stopbits the new number of stop bits setting.
      */
     public void setStopbits(int stopbits) {
         if (stopbits <0 || stopbits > 3) {

--- a/src/test/java/com/ghgande/j2mod/modbus/net/SerialConnectionTest.java
+++ b/src/test/java/com/ghgande/j2mod/modbus/net/SerialConnectionTest.java
@@ -1,0 +1,85 @@
+package com.ghgande.j2mod.modbus.net;
+
+import com.ghgande.j2mod.modbus.util.SerialParameters;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class SerialConnectionTest {
+
+	@Test
+	public void testBitsPerCharacter_Standard8N1() {
+		SerialParameters parameters = new SerialParameters("", 9600,
+				AbstractSerialConnection.FLOW_CONTROL_DISABLED,
+				AbstractSerialConnection.FLOW_CONTROL_DISABLED,
+				8,
+				AbstractSerialConnection.ONE_STOP_BIT,
+				AbstractSerialConnection.NO_PARITY,
+				false
+		);
+		SerialConnection serialCon = new SerialConnection(parameters);
+
+		// 1 Startbit + 8 Datenbits + 0 Parität + 1 Stoppbit = 10
+		assertEquals(10.0, serialCon.getBitsPerCharacter(), 0.001);
+	}
+
+	@Test
+	public void testBitsPerCharacter_FiveBitsAndOnePointFiveStopBits() {
+		SerialParameters parameters = new SerialParameters("", 9600,
+				AbstractSerialConnection.FLOW_CONTROL_DISABLED,
+				AbstractSerialConnection.FLOW_CONTROL_DISABLED,
+				5,
+				AbstractSerialConnection.ONE_POINT_FIVE_STOP_BITS,
+				AbstractSerialConnection.NO_PARITY,
+				false
+		);
+		SerialConnection serialCon = new SerialConnection(parameters);
+
+		// 1 Startbit + 5 Datenbits + 0 Parität + 1.5 Stoppbit = 7.5
+		assertEquals(7.5, serialCon.getBitsPerCharacter(), 0.001);
+	}
+
+	@Test
+	public void testBitsPerCharacter_WithParityAndTwoStopBits() {
+		SerialParameters parameters = new SerialParameters("", 9600,
+				AbstractSerialConnection.FLOW_CONTROL_DISABLED,
+				AbstractSerialConnection.FLOW_CONTROL_DISABLED,
+				8,
+				AbstractSerialConnection.TWO_STOP_BITS,
+				AbstractSerialConnection.MARK_PARITY,
+				false
+		);
+		SerialConnection serialCon = new SerialConnection(parameters);
+
+		// 1 Startbit + 8 Datenbits + 1 Parität + 2 Stoppbits = 12
+		assertEquals(12.0, serialCon.getBitsPerCharacter(), 0.001);
+	}
+
+	@Test
+	public void testStopBits_OneStopBits() {
+		SerialParameters parameters = new SerialParameters();
+		parameters.setStopbits(AbstractSerialConnection.ONE_STOP_BIT);
+
+		SerialConnection serialCon = new SerialConnection(parameters);
+		assertEquals(1.0, serialCon.getStopBits(), 0.001);
+	}
+
+	@Test
+	public void testStopBits_OnePointFiveStopBits() {
+		SerialParameters parameters = new SerialParameters();
+		parameters.setStopbits(AbstractSerialConnection.ONE_POINT_FIVE_STOP_BITS);
+
+		SerialConnection serialCon = new SerialConnection(parameters);
+		assertEquals(1.5, serialCon.getStopBits(), 0.001);
+	}
+
+	@Test
+	public void testStopBits_TwoStopBits() {
+		SerialParameters parameters = new SerialParameters();
+		parameters.setStopbits(AbstractSerialConnection.TWO_STOP_BITS);
+
+		SerialConnection serialCon = new SerialConnection(parameters);
+		assertEquals(2.0, serialCon.getStopBits(), 0.001);
+	}
+
+}

--- a/src/test/java/com/ghgande/j2mod/modbus/net/SerialConnectionTest.java
+++ b/src/test/java/com/ghgande/j2mod/modbus/net/SerialConnectionTest.java
@@ -7,79 +7,79 @@ import static org.junit.Assert.assertEquals;
 
 public class SerialConnectionTest {
 
-	@Test
-	public void testBitsPerCharacter_Standard8N1() {
-		SerialParameters parameters = new SerialParameters("", 9600,
-				AbstractSerialConnection.FLOW_CONTROL_DISABLED,
-				AbstractSerialConnection.FLOW_CONTROL_DISABLED,
-				8,
-				AbstractSerialConnection.ONE_STOP_BIT,
-				AbstractSerialConnection.NO_PARITY,
-				false
-		);
-		SerialConnection serialCon = new SerialConnection(parameters);
+    @Test
+    public void testBitsPerCharacter_Standard8N1() {
+        SerialParameters parameters = new SerialParameters("", 9600,
+                AbstractSerialConnection.FLOW_CONTROL_DISABLED,
+                AbstractSerialConnection.FLOW_CONTROL_DISABLED,
+                8,
+                AbstractSerialConnection.ONE_STOP_BIT,
+                AbstractSerialConnection.NO_PARITY,
+                false
+        );
+        SerialConnection serialCon = new SerialConnection(parameters);
 
-		// 1 start-bit + 8 data-bits + 0 parity + 1 stop-bit = 10
-		assertEquals(10.0, serialCon.getBitsPerCharacter(), 0.001);
-	}
+        // 1 start-bit + 8 data-bits + 0 parity + 1 stop-bit = 10
+        assertEquals(10.0, serialCon.getBitsPerCharacter(), 0.001);
+    }
 
-	@Test
-	public void testBitsPerCharacter_FiveBitsAndOnePointFiveStopBits() {
-		SerialParameters parameters = new SerialParameters("", 9600,
-				AbstractSerialConnection.FLOW_CONTROL_DISABLED,
-				AbstractSerialConnection.FLOW_CONTROL_DISABLED,
-				5,
-				AbstractSerialConnection.ONE_POINT_FIVE_STOP_BITS,
-				AbstractSerialConnection.NO_PARITY,
-				false
-		);
-		SerialConnection serialCon = new SerialConnection(parameters);
+    @Test
+    public void testBitsPerCharacter_FiveBitsAndOnePointFiveStopBits() {
+        SerialParameters parameters = new SerialParameters("", 9600,
+                AbstractSerialConnection.FLOW_CONTROL_DISABLED,
+                AbstractSerialConnection.FLOW_CONTROL_DISABLED,
+                5,
+                AbstractSerialConnection.ONE_POINT_FIVE_STOP_BITS,
+                AbstractSerialConnection.NO_PARITY,
+                false
+        );
+        SerialConnection serialCon = new SerialConnection(parameters);
 
-		// 1 start-bit + 5 data-bits + 0 parity + 1.5 stop-bits = 7.5
-		assertEquals(7.5, serialCon.getBitsPerCharacter(), 0.001);
-	}
+        // 1 start-bit + 5 data-bits + 0 parity + 1.5 stop-bits = 7.5
+        assertEquals(7.5, serialCon.getBitsPerCharacter(), 0.001);
+    }
 
-	@Test
-	public void testBitsPerCharacter_WithParityAndTwoStopBits() {
-		SerialParameters parameters = new SerialParameters("", 9600,
-				AbstractSerialConnection.FLOW_CONTROL_DISABLED,
-				AbstractSerialConnection.FLOW_CONTROL_DISABLED,
-				8,
-				AbstractSerialConnection.TWO_STOP_BITS,
-				AbstractSerialConnection.MARK_PARITY,
-				false
-		);
-		SerialConnection serialCon = new SerialConnection(parameters);
+    @Test
+    public void testBitsPerCharacter_WithParityAndTwoStopBits() {
+        SerialParameters parameters = new SerialParameters("", 9600,
+                AbstractSerialConnection.FLOW_CONTROL_DISABLED,
+                AbstractSerialConnection.FLOW_CONTROL_DISABLED,
+                8,
+                AbstractSerialConnection.TWO_STOP_BITS,
+                AbstractSerialConnection.MARK_PARITY,
+                false
+        );
+        SerialConnection serialCon = new SerialConnection(parameters);
 
-		// 1 start-bit + 8 data-bits + 1 parity + 2 stop-bits = 12
-		assertEquals(12.0, serialCon.getBitsPerCharacter(), 0.001);
-	}
+        // 1 start-bit + 8 data-bits + 1 parity + 2 stop-bits = 12
+        assertEquals(12.0, serialCon.getBitsPerCharacter(), 0.001);
+    }
 
-	@Test
-	public void testStopBits_OneStopBits() {
-		SerialParameters parameters = new SerialParameters();
-		parameters.setStopbits(AbstractSerialConnection.ONE_STOP_BIT);
+    @Test
+    public void testStopBits_OneStopBits() {
+        SerialParameters parameters = new SerialParameters();
+        parameters.setStopbits(AbstractSerialConnection.ONE_STOP_BIT);
 
-		SerialConnection serialCon = new SerialConnection(parameters);
-		assertEquals(1.0, serialCon.getStopBits(), 0.001);
-	}
+        SerialConnection serialCon = new SerialConnection(parameters);
+        assertEquals(1.0, serialCon.getStopBits(), 0.001);
+    }
 
-	@Test
-	public void testStopBits_OnePointFiveStopBits() {
-		SerialParameters parameters = new SerialParameters();
-		parameters.setStopbits(AbstractSerialConnection.ONE_POINT_FIVE_STOP_BITS);
+    @Test
+    public void testStopBits_OnePointFiveStopBits() {
+        SerialParameters parameters = new SerialParameters();
+        parameters.setStopbits(AbstractSerialConnection.ONE_POINT_FIVE_STOP_BITS);
 
-		SerialConnection serialCon = new SerialConnection(parameters);
-		assertEquals(1.5, serialCon.getStopBits(), 0.001);
-	}
+        SerialConnection serialCon = new SerialConnection(parameters);
+        assertEquals(1.5, serialCon.getStopBits(), 0.001);
+    }
 
-	@Test
-	public void testStopBits_TwoStopBits() {
-		SerialParameters parameters = new SerialParameters();
-		parameters.setStopbits(AbstractSerialConnection.TWO_STOP_BITS);
+    @Test
+    public void testStopBits_TwoStopBits() {
+        SerialParameters parameters = new SerialParameters();
+        parameters.setStopbits(AbstractSerialConnection.TWO_STOP_BITS);
 
-		SerialConnection serialCon = new SerialConnection(parameters);
-		assertEquals(2.0, serialCon.getStopBits(), 0.001);
-	}
+        SerialConnection serialCon = new SerialConnection(parameters);
+        assertEquals(2.0, serialCon.getStopBits(), 0.001);
+    }
 
 }

--- a/src/test/java/com/ghgande/j2mod/modbus/net/SerialConnectionTest.java
+++ b/src/test/java/com/ghgande/j2mod/modbus/net/SerialConnectionTest.java
@@ -19,7 +19,7 @@ public class SerialConnectionTest {
 		);
 		SerialConnection serialCon = new SerialConnection(parameters);
 
-		// 1 Startbit + 8 Datenbits + 0 Parität + 1 Stoppbit = 10
+		// 1 start-bit + 8 data-bits + 0 parity + 1 stop-bit = 10
 		assertEquals(10.0, serialCon.getBitsPerCharacter(), 0.001);
 	}
 
@@ -35,7 +35,7 @@ public class SerialConnectionTest {
 		);
 		SerialConnection serialCon = new SerialConnection(parameters);
 
-		// 1 Startbit + 5 Datenbits + 0 Parität + 1.5 Stoppbit = 7.5
+		// 1 start-bit + 5 data-bits + 0 parity + 1.5 stop-bits = 7.5
 		assertEquals(7.5, serialCon.getBitsPerCharacter(), 0.001);
 	}
 
@@ -51,7 +51,7 @@ public class SerialConnectionTest {
 		);
 		SerialConnection serialCon = new SerialConnection(parameters);
 
-		// 1 Startbit + 8 Datenbits + 1 Parität + 2 Stoppbits = 12
+		// 1 start-bit + 8 data-bits + 1 parity + 2 stop-bits = 12
 		assertEquals(12.0, serialCon.getBitsPerCharacter(), 0.001);
 	}
 

--- a/src/test/java/com/ghgande/j2mod/modbus/util/SerialParametersTest.java
+++ b/src/test/java/com/ghgande/j2mod/modbus/util/SerialParametersTest.java
@@ -5,6 +5,7 @@ import com.ghgande.j2mod.modbus.net.AbstractSerialConnection;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 public class SerialParametersTest {
 
@@ -171,5 +172,14 @@ public class SerialParametersTest {
     public void testSetFlowControlOut() {
         SerialParameters serialParameters = new SerialParameters();
         serialParameters.setFlowControlOut(-1);
+    }
+
+    @Test
+    public void testInvalidBaudRatesThrowException() {
+        SerialParameters serialParameters = new SerialParameters();
+        assertThrows(IllegalArgumentException.class, () -> serialParameters.setBaudRate(0));
+        assertThrows(IllegalArgumentException.class, () -> serialParameters.setBaudRate(-1));
+        assertThrows(IllegalArgumentException.class, () -> serialParameters.setBaudRate("0"));
+        assertThrows(IllegalArgumentException.class, () -> serialParameters.setBaudRate("-1"));
     }
 }


### PR DESCRIPTION
This pull request updates the Modbus serial communication logic to better align with the MODBUS over Serial Line Specification V1.02, refine timing calculations, and expand unit test coverage.

**Serial timing and specification alignment:**
* Updated inter-frame (3.5t) and inter-character (1.5t) delay calculations in ModbusSerialTransport
* Corrected the inter-frame gap constant to 3.5 characters. Use round-up instead of a higher fixed 4-char gap
* Switched character interval calculations to microsecond-level precision
* Fixed the inter-character time-out, to be 750us instead of 1750us on baud-rates >19200

**Serial parameter handling & validation:**
* Refactored SerialParameters constructors to cascade from fewer parameters down to the primary constructor, for proper constructor chaining
* added explicit validation for baud rates (>1).